### PR TITLE
Mpconfig cl fix

### DIFF
--- a/core/src/main/java/io/smallrye/context/SmallRyeContextManager.java
+++ b/core/src/main/java/io/smallrye/context/SmallRyeContextManager.java
@@ -14,6 +14,7 @@ import org.eclipse.microprofile.context.spi.ContextManager;
 import org.eclipse.microprofile.context.spi.ContextManagerExtension;
 import org.eclipse.microprofile.context.spi.ThreadContextProvider;
 
+import io.smallrye.context.impl.DefaultValues;
 import io.smallrye.context.impl.ManagedExecutorBuilderImpl;
 import io.smallrye.context.impl.ThreadContextBuilderImpl;
 import io.smallrye.context.impl.ThreadContextProviderPlan;
@@ -30,6 +31,8 @@ public class SmallRyeContextManager implements ContextManager {
 
     private String[] allProviderTypes;
 
+    private DefaultValues defaultValues;
+
     SmallRyeContextManager(List<ThreadContextProvider> providers, List<ContextManagerExtension> extensions) {
         this.providers = new ArrayList<ThreadContextProvider>(providers);
         providersByType = new HashMap<>();
@@ -40,6 +43,8 @@ public class SmallRyeContextManager implements ContextManager {
         // FIXME: check for cycles
         allProviderTypes = providersByType.keySet().toArray(new String[this.providers.size()]);
         this.extensions = new ArrayList<ContextManagerExtension>(extensions);
+        this.defaultValues = new DefaultValues();
+        // Extensions may call our methods, so do all init before we call this
         for (ContextManagerExtension extension : extensions) {
             extension.setup(this);
         }
@@ -152,5 +157,9 @@ public class SmallRyeContextManager implements ContextManager {
     // For tests
     public List<ContextManagerExtension> getExtensions() {
         return extensions;
+    }
+
+    public DefaultValues getDefaultValues() {
+        return defaultValues;
     }
 }

--- a/core/src/main/java/io/smallrye/context/impl/DefaultValues.java
+++ b/core/src/main/java/io/smallrye/context/impl/DefaultValues.java
@@ -16,9 +16,6 @@ import java.util.NoSuchElementException;
  */
 public class DefaultValues {
 
-    // single instance
-    public static final DefaultValues INSTANCE = new DefaultValues();
-
     // constants defined by spec for MP Config
     private final String EXEC_ASYNC = "ManagedExecutor/maxAsync";
     private final String EXEC_QUEUE = "ManagedExecutor/maxQueued";
@@ -37,7 +34,7 @@ public class DefaultValues {
     private String[] threadCleared;
     private String[] threadUnchanged;
 
-    private DefaultValues() {
+    public DefaultValues() {
         // NOTE: we do not perform sanity check here, that's done in SmallRyeContextManager
         Config config = ConfigProvider.getConfig();
         this.executorAsync = config.getOptionalValue(EXEC_ASYNC, Integer.class)
@@ -54,7 +51,7 @@ public class DefaultValues {
         this.threadUnchanged = resolveConfiguration(config, THREAD_UNCHANGED, SmallRyeContextManager.NO_STRING);
     }
 
-    private static String[] resolveConfiguration(Config mpConfig, String key, String[] originalValue) {
+    private String[] resolveConfiguration(Config mpConfig, String key, String[] originalValue) {
         try {
             return mpConfig.getValue(key, String[].class);
         } catch (NoSuchElementException e) {

--- a/core/src/main/java/io/smallrye/context/impl/ManagedExecutorBuilderImpl.java
+++ b/core/src/main/java/io/smallrye/context/impl/ManagedExecutorBuilderImpl.java
@@ -16,11 +16,12 @@ public class ManagedExecutorBuilderImpl implements ManagedExecutor.Builder {
 
     public ManagedExecutorBuilderImpl(SmallRyeContextManager manager) {
         this.manager = manager;
+        DefaultValues defaultValues = manager.getDefaultValues();
         // initiate with default values
-        this.propagated = DefaultValues.INSTANCE.getExecutorPropagated();
-        this.cleared = DefaultValues.INSTANCE.getExecutorCleared();
-        this.maxAsync = DefaultValues.INSTANCE.getExecutorAsync();
-        this.maxQueued = DefaultValues.INSTANCE.getExecutorQueue();
+        this.propagated = defaultValues.getExecutorPropagated();
+        this.cleared = defaultValues.getExecutorCleared();
+        this.maxAsync = defaultValues.getExecutorAsync();
+        this.maxQueued = defaultValues.getExecutorQueue();
     }
 
     @Override

--- a/core/src/main/java/io/smallrye/context/impl/ThreadContextBuilderImpl.java
+++ b/core/src/main/java/io/smallrye/context/impl/ThreadContextBuilderImpl.java
@@ -14,9 +14,10 @@ public class ThreadContextBuilderImpl implements ThreadContext.Builder {
 
     public ThreadContextBuilderImpl(SmallRyeContextManager manager) {
         this.manager = manager;
-        this.propagated = DefaultValues.INSTANCE.getThreadPropagated();
-        this.unchanged = DefaultValues.INSTANCE.getThreadUnchanged();
-        this.cleared = DefaultValues.INSTANCE.getThreadCleared();
+        DefaultValues defaultValues = manager.getDefaultValues();
+        this.propagated = defaultValues.getThreadPropagated();
+        this.unchanged = defaultValues.getThreadUnchanged();
+        this.cleared = defaultValues.getThreadCleared();
     }
 
     @Override

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -176,7 +176,7 @@
                 <version>2.22.0</version>
                 <configuration>
                     <dependenciesToScan>
-                        <dependency>org.eclipse.microprofile.context:microprofile-context-tck</dependency>
+                        <dependency>org.eclipse.microprofile.context-propagation:microprofile-context-propagation-tck</dependency>
                     </dependenciesToScan>
                 </configuration>
             </plugin>

--- a/tests/src/test/java/io/smallrye/context/test/classloading/MultiClassloadingTest.java
+++ b/tests/src/test/java/io/smallrye/context/test/classloading/MultiClassloadingTest.java
@@ -21,19 +21,27 @@ package io.smallrye.context.test.classloading;
 import java.util.Map;
 import java.util.function.BiConsumer;
 
+import javax.enterprise.util.AnnotationLiteral;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.eclipse.microprofile.context.ThreadContext;
 import org.eclipse.microprofile.context.spi.ContextManager;
 import org.eclipse.microprofile.context.spi.ContextManagerExtension;
 import org.eclipse.microprofile.context.spi.ContextManagerProvider;
 import org.eclipse.microprofile.context.spi.ThreadContextProvider;
 import org.eclipse.microprofile.context.spi.ThreadContextSnapshot;
+import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.classloader.ShrinkWrapClassLoader;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
 import org.junit.Test;
 
+import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.SmallRyeConfigProviderResolver;
 import io.smallrye.context.SmallRyeContextManagerProvider;
+import io.smallrye.context.api.ManagedExecutorConfig;
 import io.smallrye.context.impl.ThreadContextImpl;
 
 public class MultiClassloadingTest {
@@ -106,11 +114,17 @@ public class MultiClassloadingTest {
 
         JavaArchive parentJar = ShrinkWrap.create(JavaArchive.class).addPackages(true, ThreadContext.class.getPackage().getName())
                 .addPackages(true, Assert.class.getPackage().getName())
+                .addPackages(true, ConfigProvider.class.getPackage().getName())
+                .addPackages(true, SmallRyeConfig.class.getPackage().getName())
+                .addPackages(true, Logger.class.getPackage().getName())
+                .addPackage(AnnotationLiteral.class.getPackage().getName())
                 // done use addPackages for Smallrye-Context because it
                 // would include test packages
                 .addPackage(SmallRyeContextManagerProvider.class.getPackage().getName())
                 .addPackage(ThreadContextImpl.class.getPackage().getName())
                 .addPackage(ContextManagerExtension.class.getPackage().getName())
+                .addPackage(ManagedExecutorConfig.class.getPackage().getName())
+                .addAsServiceProvider(ConfigProviderResolver.class, SmallRyeConfigProviderResolver.class)
                 .addAsServiceProvider(ContextManagerProvider.class, SmallRyeContextManagerProvider.class);
         ShrinkWrapClassLoader parentCL = new ShrinkWrapClassLoader((ClassLoader) null, parentJar);
         System.err.println("ParentCL: " + parentCL);


### PR DESCRIPTION
This is my fix to get rid of default values sticking around across test runs.

Also required is this fix in the TCK (after I moved the resource file to the specified folder):

```diff
-                .addAsManifestResource("META-INF/microprofile-config.properties", "microprofile-config.properties")
+                .addAsWebInfResource("org/eclipse/microprofile/context/tck/microprofile-config.properties", 
+                        "classes/META-INF/microprofile-config.properties")
```