### PR TITLE
Fix versions in tests and tck modules, bump smallrye parent version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>io.smallrye</groupId>
 		<artifactId>smallrye-parent</artifactId>
-		<version>1</version>
+		<version>2</version>
 	</parent>
 
 	<artifactId>smallrye-context-propagation-parent</artifactId>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-context-propagation-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.2-SNAPSHOT</version>
     </parent>
     <artifactId>smallrye-context-propagation-tck</artifactId>
     <name>smallrye-context-propagation-tck</name>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-context-propagation-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.2-SNAPSHOT</version>
     </parent>
     <artifactId>smallrye-context-propagation-test</artifactId>
     <name>smallrye-context-propagation-test</name>


### PR DESCRIPTION
@FroMage apparently, the release plugin still isn't set up properly. The tck and tests module weren't updated in regards to versions. Not that I'd know how to do that, but I'll try asking around. Meanwhile, here is a fix to make it buildable again.