### PR TITLE
Add tests for overriding ME/TC IPs via MP config.

### DIFF
--- a/tests/src/test/java/io/smallrye/context/test/cdi/providedBeans/BeanWithInjectionPoints.java
+++ b/tests/src/test/java/io/smallrye/context/test/cdi/providedBeans/BeanWithInjectionPoints.java
@@ -19,6 +19,10 @@ import io.smallrye.context.api.NamedInstance;
 import io.smallrye.context.api.ThreadContextConfig;
 import io.smallrye.context.impl.ThreadContextProviderPlan;
 
+import static io.smallrye.context.test.cdi.providedBeans.Utils.providersToStringSet;
+import static io.smallrye.context.test.cdi.providedBeans.Utils.unwrapExecutor;
+import static io.smallrye.context.test.cdi.providedBeans.Utils.unwrapThreadContext;
+
 /**
  * There are multiple context providers added in tests, we do not assert on those and only look for CDI and JTA now.
  */
@@ -115,29 +119,5 @@ public class BeanWithInjectionPoints {
         Set<String> propagated = providersToStringSet(plan.propagatedProviders);
         Assert.assertTrue(propagated.contains(ThreadContext.CDI));
         Assert.assertTrue(propagated.contains(ThreadContext.TRANSACTION));
-    }
-
-    private SmallRyeManagedExecutor unwrapExecutor(ManagedExecutor executor) {
-        if (executor instanceof WeldClientProxy) {
-            return (SmallRyeManagedExecutor) ((WeldClientProxy) executor).getMetadata().getContextualInstance();
-        } else {
-            throw new IllegalStateException("Injected proxies are expected to be instance of WeldClientProxy");
-        }
-    }
-
-    private SmallRyeThreadContext unwrapThreadContext(ThreadContext executor) {
-        if (executor instanceof WeldClientProxy) {
-            return (SmallRyeThreadContext) ((WeldClientProxy) executor).getMetadata().getContextualInstance();
-        } else {
-            throw new IllegalStateException("Injected proxies are expected to be instance of WeldClientProxy");
-        }
-    }
-
-    private Set<String> providersToStringSet(Set<ThreadContextProvider> providers) {
-        Set<String> result = new HashSet<>();
-        for (ThreadContextProvider provider : providers) {
-            result.add(provider.getThreadContextType());
-        }
-        return result;
     }
 }

--- a/tests/src/test/java/io/smallrye/context/test/cdi/providedBeans/Utils.java
+++ b/tests/src/test/java/io/smallrye/context/test/cdi/providedBeans/Utils.java
@@ -1,0 +1,41 @@
+package io.smallrye.context.test.cdi.providedBeans;
+
+import io.smallrye.context.SmallRyeManagedExecutor;
+import io.smallrye.context.SmallRyeThreadContext;
+import org.eclipse.microprofile.context.ManagedExecutor;
+import org.eclipse.microprofile.context.ThreadContext;
+import org.eclipse.microprofile.context.spi.ThreadContextProvider;
+import org.jboss.weld.proxy.WeldClientProxy;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class Utils {
+
+    private Utils() {
+    }
+
+    public static SmallRyeManagedExecutor unwrapExecutor(ManagedExecutor executor) {
+        if (executor instanceof WeldClientProxy) {
+            return (SmallRyeManagedExecutor) ((WeldClientProxy) executor).getMetadata().getContextualInstance();
+        } else {
+            throw new IllegalStateException("Injected proxies are expected to be instance of WeldClientProxy");
+        }
+    }
+
+    public static SmallRyeThreadContext unwrapThreadContext(ThreadContext executor) {
+        if (executor instanceof WeldClientProxy) {
+            return (SmallRyeThreadContext) ((WeldClientProxy) executor).getMetadata().getContextualInstance();
+        } else {
+            throw new IllegalStateException("Injected proxies are expected to be instance of WeldClientProxy");
+        }
+    }
+
+    public static Set<String> providersToStringSet(Set<ThreadContextProvider> providers) {
+        Set<String> result = new HashSet<>();
+        for (ThreadContextProvider provider : providers) {
+            result.add(provider.getThreadContextType());
+        }
+        return result;
+    }
+}

--- a/tests/src/test/java/io/smallrye/context/test/cdi/providedBeans/microprofileConfiguration/MpConfigOverridingConfigurationTest.java
+++ b/tests/src/test/java/io/smallrye/context/test/cdi/providedBeans/microprofileConfiguration/MpConfigOverridingConfigurationTest.java
@@ -1,0 +1,62 @@
+package io.smallrye.context.test.cdi.providedBeans.microprofileConfiguration;
+
+import io.smallrye.context.SmallRyeManagedExecutor;
+import io.smallrye.context.SmallRyeThreadContext;
+import io.smallrye.context.impl.ThreadContextProviderPlan;
+import io.smallrye.context.test.cdi.providedBeans.Utils;
+import org.eclipse.microprofile.context.ThreadContext;
+import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.environment.se.WeldContainer;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Set;
+
+public class MpConfigOverridingConfigurationTest {
+
+    @Test
+    public void testOverridingIPsWithMpConfig() {
+        try (WeldContainer container = new Weld().addBeanClass(SomeBean.class).initialize()) {
+            SomeBean bean = container.select(SomeBean.class).get();
+            // verify standard field IPs
+            verifyManagedExecutor(Utils.unwrapExecutor(bean.getOverrideDefaultME()));
+            verifyManagedExecutor(Utils.unwrapExecutor(bean.getOverrideConfiguredME()));
+            verifyThreadContext(Utils.unwrapThreadContext(bean.getOverrideDefaultTC()));
+            verifyThreadContext(Utils.unwrapThreadContext(bean.getOverrideConfiguredTC()));
+            // verify IP as method parameter where we set empty value via MP config
+            container.event().select(String.class).fire("foo");
+            Assert.assertTrue(SomeBean.OBSERVER_NOTIFIED);
+            ThreadContextProviderPlan plan = Utils.unwrapExecutor(bean.getExecutorFromObserverMethod()).getThreadContextProviderPlan();
+            Set<String> propagated = Utils.providersToStringSet(plan.propagatedProviders);
+            Assert.assertTrue(propagated.contains(ThreadContext.TRANSACTION));
+            Assert.assertTrue(propagated.contains(ThreadContext.CDI));
+            Assert.assertTrue(plan.clearedProviders.size() == 0);
+            Assert.assertTrue(plan.unchangedProviders.size() == 0);
+        }
+    }
+
+    private void verifyManagedExecutor(SmallRyeManagedExecutor me) {
+        Assert.assertEquals(-1, me.getMaxQueued());
+        // max async is overriden by MP config
+        Assert.assertEquals(2, me.getMaxAsync());
+        ThreadContextProviderPlan threadContextProviderPlan = me.getThreadContextProviderPlan();
+        // CDI context is moved to cleared contexts by MP config
+        Assert.assertTrue(threadContextProviderPlan.clearedProviders.size() == 1);
+        Assert.assertEquals(ThreadContext.CDI, threadContextProviderPlan.clearedProviders.iterator().next().getThreadContextType());
+        // indirectly verify that propagated contained all remaining, e.g. transactions will be there
+        Set<String> propagated = Utils.providersToStringSet(threadContextProviderPlan.propagatedProviders);
+        Assert.assertTrue(propagated.contains(ThreadContext.TRANSACTION));
+        Assert.assertTrue(threadContextProviderPlan.unchangedProviders.size() == 0);
+    }
+
+    private void verifyThreadContext(SmallRyeThreadContext tc) {
+        ThreadContextProviderPlan threadContextProviderPlan = tc.getPlan();
+        // CDI context is moved to cleared contexts by MP config
+        Assert.assertTrue(threadContextProviderPlan.clearedProviders.size() == 1);
+        Assert.assertEquals(ThreadContext.CDI, threadContextProviderPlan.clearedProviders.iterator().next().getThreadContextType());
+        // indirectly verify that propagated contained all remaining, e.g. transactions will be there
+        Set<String> propagated = Utils.providersToStringSet(threadContextProviderPlan.propagatedProviders);
+        Assert.assertTrue(propagated.contains(ThreadContext.TRANSACTION));
+        Assert.assertTrue(threadContextProviderPlan.unchangedProviders.size() == 0);
+    }
+}

--- a/tests/src/test/java/io/smallrye/context/test/cdi/providedBeans/microprofileConfiguration/SomeBean.java
+++ b/tests/src/test/java/io/smallrye/context/test/cdi/providedBeans/microprofileConfiguration/SomeBean.java
@@ -1,0 +1,64 @@
+package io.smallrye.context.test.cdi.providedBeans.microprofileConfiguration;
+
+import io.smallrye.context.api.ManagedExecutorConfig;
+import io.smallrye.context.api.NamedInstance;
+import io.smallrye.context.api.ThreadContextConfig;
+import org.eclipse.microprofile.context.ManagedExecutor;
+import org.eclipse.microprofile.context.ThreadContext;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+/**
+ * MP config overrides all the ME and TC injection points in some aspect.
+ * Presence/absence of @NamedInstance shouldn't change the functionality.
+ */
+@ApplicationScoped
+public class SomeBean {
+
+    public static boolean OBSERVER_NOTIFIED = false;
+
+    @Inject
+    private ManagedExecutor overrideDefaultME;
+
+    @Inject
+    @NamedInstance("configuredME")
+    @ManagedExecutorConfig(cleared = "", maxAsync = -1, maxQueued = -1, propagated = ThreadContext.ALL_REMAINING)
+    private ManagedExecutor overrideConfiguredME;
+
+    @Inject
+    @NamedInstance("defaultTC")
+    private ThreadContext overrideDefaultTC;
+
+    @Inject
+    @ThreadContextConfig(propagated = ThreadContext.ALL_REMAINING, cleared = "", unchanged = "")
+    private ThreadContext overrideConfiguredTC;
+
+    private ManagedExecutor executorFromObserverMethod;
+
+    public ManagedExecutor getOverrideDefaultME() {
+        return overrideDefaultME;
+    }
+
+    public ManagedExecutor getOverrideConfiguredME() {
+        return overrideConfiguredME;
+    }
+
+    public ManagedExecutor getExecutorFromObserverMethod() {
+        return executorFromObserverMethod;
+    }
+
+    public ThreadContext getOverrideDefaultTC() {
+        return overrideDefaultTC;
+    }
+
+    public ThreadContext getOverrideConfiguredTC() {
+        return overrideConfiguredTC;
+    }
+
+    public void observeSomething(@Observes String payload, @ManagedExecutorConfig(cleared = ThreadContext.CDI) ManagedExecutor parameterME) {
+        OBSERVER_NOTIFIED = true;
+        executorFromObserverMethod = parameterME;
+    }
+}

--- a/tests/src/test/resources/META-INF/microprofile-config.properties
+++ b/tests/src/test/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,7 @@
+io.smallrye.context.test.cdi.providedBeans.microprofileConfiguration.SomeBean/overrideDefaultME/ManagedExecutorConfig/cleared=CDI
+io.smallrye.context.test.cdi.providedBeans.microprofileConfiguration.SomeBean/overrideDefaultME/ManagedExecutorConfig/maxAsync=2
+io.smallrye.context.test.cdi.providedBeans.microprofileConfiguration.SomeBean/overrideConfiguredME/ManagedExecutorConfig/cleared=CDI
+io.smallrye.context.test.cdi.providedBeans.microprofileConfiguration.SomeBean/overrideConfiguredME/ManagedExecutorConfig/maxAsync=2
+io.smallrye.context.test.cdi.providedBeans.microprofileConfiguration.SomeBean/overrideDefaultTC/ThreadContextConfig/cleared=CDI
+io.smallrye.context.test.cdi.providedBeans.microprofileConfiguration.SomeBean/overrideConfiguredTC/ThreadContextConfig/cleared=CDI
+io.smallrye.context.test.cdi.providedBeans.microprofileConfiguration.SomeBean/observeSomething/2/ManagedExecutorConfig/cleared=


### PR DESCRIPTION
Resolves #52 
Just a bunch of tests that verify overriding injection points of `ManagedExecutor` and `ThreadContext` with MP config.

The workaround we have for empty values is still needed (removing it will show failure in this test) so it stays in place for now.