### PR TITLE
Bump MP CP version to 1.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 	</scm>
 
 	<properties>
-		<version.microprofile.context-propagation>1.0</version.microprofile.context-propagation>
+		<version.microprofile.context-propagation>1.0.1</version.microprofile.context-propagation>
 		<version.microprofile.config>1.3</version.microprofile.config>
 		<version.smallrye.config>1.3.9</version.smallrye.config>
         <version.jboss.threads>3.0.0.Final</version.jboss.threads>


### PR DESCRIPTION
1.0.1 is out - https://github.com/eclipse/microprofile-context-propagation/releases/tag/1.0.1

It contains basically just some TCK fixes (which will fix it for us in Quarkus).