### PR TITLE
Defer initialisation of the Config

### DIFF
--- a/tests/src/test/java/io/smallrye/context/test/BackPressureExceptionTest.java
+++ b/tests/src/test/java/io/smallrye/context/test/BackPressureExceptionTest.java
@@ -1,15 +1,15 @@
 package io.smallrye.context.test;
 
-import io.reactivex.observers.TestObserver;
-import io.smallrye.context.SmallRyeContextManagerProvider;
-import rx.observers.AssertableSubscriber;
+import static java.util.Arrays.asList;
+
+import java.util.concurrent.TimeUnit;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.concurrent.TimeUnit;
-
-import static java.util.Arrays.asList;
+import io.reactivex.observers.TestObserver;
+import io.smallrye.context.SmallRyeContextManagerProvider;
+import rx.observers.AssertableSubscriber;
 
 public class BackPressureExceptionTest {
 
@@ -19,30 +19,27 @@ public class BackPressureExceptionTest {
         SmallRyeContextManagerProvider.getManager();
     }
 
-
     @Test
     public void testBackPressureRxJava1() {
-        AssertableSubscriber<Integer> test =
-            rx.Observable.from(asList(1,2,3,4,5,6))
+        AssertableSubscriber<Integer> test = rx.Observable.from(asList(1, 2, 3, 4, 5, 6))
                 .concatMap(integer -> rx.Observable.just(integer).delay(100, TimeUnit.MILLISECONDS))
                 .test();
 
         test.awaitTerminalEvent();
 
         test.assertNoErrors();
-        test.assertReceivedOnNext(asList(1,2,3,4,5,6));
+        test.assertReceivedOnNext(asList(1, 2, 3, 4, 5, 6));
     }
 
     @Test
     public void testBackPressureRxJava2() {
-        TestObserver<Integer> test =
-            io.reactivex.Observable.just(1,2,3,4,5,6)
+        TestObserver<Integer> test = io.reactivex.Observable.just(1, 2, 3, 4, 5, 6)
                 .concatMap(integer -> io.reactivex.Observable.just(integer).delay(100, TimeUnit.MILLISECONDS))
                 .test();
 
         test.awaitTerminalEvent();
 
         test.assertNoErrors();
-        test.assertValues(1,2,3,4,5,6);
+        test.assertValues(1, 2, 3, 4, 5, 6);
     }
 }


### PR DESCRIPTION
In WildFly I found that the call to ContextProvider.getConfig() was happening too early. It happens when we load up all the CDI portable extensions (SmallryeContextCdiExtension is one of them), and results in a call to SmallRyeConfigProviderResolver.getConfig() which lazily registers the config against the deployment classloader.

Later in the deployment chain, we have a deployer which calls SmallRyeConfigProviderResolver.registerConfig(). This was made stricter
in SmallRyeConfig 1.4.x (we were previously on 1.3.x) and now fails if the classloader was already registered. 

It does not seem to happen with other MP specs, which is what led me here. 

With this change I am able to deploy context propagation deployments into WildFly  and pass the TCK again.
