### PR TITLE
Improve JTA performance

### DIFF
--- a/tck/src/test/java/io/smallrye/context/tck/lifecycle/LifecycleExecuter.java
+++ b/tck/src/test/java/io/smallrye/context/tck/lifecycle/LifecycleExecuter.java
@@ -10,7 +10,7 @@
  * You may obtain a copy of the License at
  * http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,  
+ * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
@@ -20,13 +20,18 @@ package io.smallrye.context.tck.lifecycle;
 import java.lang.reflect.Method;
 
 import org.jboss.arquillian.container.spi.event.container.AfterDeploy;
+import org.jboss.arquillian.container.spi.event.container.BeforeDeploy;
 import org.jboss.arquillian.container.spi.event.container.BeforeUnDeploy;
 import org.jboss.arquillian.core.api.annotation.Observes;
 import org.jboss.arquillian.test.spi.TestClass;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.container.ClassContainer;
 import org.jnp.server.NamingBeanImpl;
 
 import com.arjuna.ats.arjuna.common.arjPropertyManager;
 import com.arjuna.ats.jta.utils.JNDIManager;
+
+import io.smallrye.context.jta.context.propagation.JtaContextProvider;
 
 /**
  * LifecycleExecuter
@@ -54,11 +59,12 @@ public class LifecycleExecuter {
         namingBean.stop();
     }
 
-    /*
-     * public void executeBeforeDeploy(@Observes BeforeDeploy event, TestClass testClass) {
-     * execute(testClass.getMethods(io.smallrye.context.tck.lifecycle.api.BeforeDeploy.class));
-     * }
-     */
+    public void executeBeforeDeploy(@Observes BeforeDeploy event, TestClass testClass) {
+        Archive<?> jar = event.getDeployment().getArchive();
+        if (jar instanceof ClassContainer<?>) {
+            ((ClassContainer<?>) jar).addClass(JtaContextProvider.LifecycleManager.class);
+        }
+    }
 
     public void executeAfterDeploy(@Observes AfterDeploy event, TestClass testClass) throws Exception {
         registerJTA();

--- a/tests/src/test/java/io/smallrye/context/test/FullStackTest.java
+++ b/tests/src/test/java/io/smallrye/context/test/FullStackTest.java
@@ -26,7 +26,6 @@ import org.jboss.resteasy.spi.HttpResponse;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.jboss.weld.context.bound.BoundRequestContext;
 import org.jboss.weld.environment.se.Weld;
-import org.jnp.server.NamingBeanImpl;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,7 +43,6 @@ public class FullStackTest {
         }
     }
 
-    private NamingBeanImpl namingBean = new NamingBeanImpl();
     private MyVertxJaxrsServer vertxJaxrsServer;
     private Weld weld;
 
@@ -55,11 +53,7 @@ public class FullStackTest {
         weld = new Weld();
         weld.initialize();
 
-        try {
-            JTATest.initJTATM();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        JTAUtils.startJTATM();
 
         ResteasyCdiExtension cdiExtension = CDI.current().select(ResteasyCdiExtension.class).get();
         deployment.setActualResourceClasses(cdiExtension.getResources());
@@ -176,7 +170,7 @@ public class FullStackTest {
     public void after() {
         weld.shutdown();
         vertxJaxrsServer.stop();
-        namingBean.stop();
+        JTAUtils.stop();
     }
 
     @Test

--- a/tests/src/test/java/io/smallrye/context/test/JTATest.java
+++ b/tests/src/test/java/io/smallrye/context/test/JTATest.java
@@ -15,39 +15,21 @@ import org.eclipse.microprofile.context.ManagedExecutor;
 import org.eclipse.microprofile.context.ThreadContext;
 import org.jboss.weld.environment.se.Weld;
 import org.jboss.weld.environment.se.WeldContainer;
-import org.jnp.server.NamingBeanImpl;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import com.arjuna.ats.arjuna.common.arjPropertyManager;
-import com.arjuna.ats.jta.utils.JNDIManager;
-
 import io.smallrye.context.inject.TransactionServicesImpl;
 import io.smallrye.context.test.jta.TransactionalService;
 
 public class JTATest {
-    private static final String txnStoreLocation = "target/tx-object-store";
-    private static NamingBeanImpl namingBean;
     private static Weld weld;
-
-    static void initJTATM() throws Exception {
-        // Start a JNDI server
-        namingBean = new NamingBeanImpl();
-        namingBean.start();
-
-        // Bind the JTA implementation to the correct JNDI contexts
-        JNDIManager.bindJTAImplementation();
-
-        // Set object store location
-        arjPropertyManager.getObjectStoreEnvironmentBean().setObjectStoreDir(txnStoreLocation);
-    }
 
     @BeforeClass
     public static void beforeClass() throws Exception {
-        initJTATM(); // initialise a transaction manager
+        JTAUtils.startJTATM(); // initialise a transaction manager
 
         weld = new Weld(); // CDI implementation
         weld.addServices(new TransactionServicesImpl());
@@ -55,7 +37,7 @@ public class JTATest {
 
     @AfterClass
     public static void afterClass() {
-        namingBean.stop();
+        JTAUtils.stop();
     }
 
     @After

--- a/tests/src/test/java/io/smallrye/context/test/JTAUtils.java
+++ b/tests/src/test/java/io/smallrye/context/test/JTAUtils.java
@@ -1,0 +1,31 @@
+package io.smallrye.context.test;
+
+import org.jnp.server.NamingBeanImpl;
+
+import com.arjuna.ats.arjuna.common.arjPropertyManager;
+import com.arjuna.ats.jta.utils.JNDIManager;
+
+public class JTAUtils {
+    private static final String txnStoreLocation = "target/tx-object-store";
+    private static NamingBeanImpl namingBean;
+
+    public static void startJTATM() {
+        try {
+            // Start a JNDI server
+            namingBean = new NamingBeanImpl();
+            namingBean.start();
+
+            // Bind the JTA implementation to the correct JNDI contexts
+            JNDIManager.bindJTAImplementation();
+
+            // Set object store location
+            arjPropertyManager.getObjectStoreEnvironmentBean().setObjectStoreDir(txnStoreLocation);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void stop() {
+        namingBean.stop();
+    }
+}

--- a/tests/src/test/java/io/smallrye/context/test/cdi/context/propagation/CdiContextPropagatesTest.java
+++ b/tests/src/test/java/io/smallrye/context/test/cdi/context/propagation/CdiContextPropagatesTest.java
@@ -10,9 +10,12 @@ import org.eclipse.microprofile.context.ManagedExecutor;
 import org.eclipse.microprofile.context.ThreadContext;
 import org.jboss.weld.environment.se.Weld;
 import org.jboss.weld.environment.se.WeldContainer;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import io.smallrye.context.test.JTAUtils;
 
 public class CdiContextPropagatesTest {
 
@@ -20,10 +23,16 @@ public class CdiContextPropagatesTest {
 
     @BeforeClass
     public static void init() {
+        JTAUtils.startJTATM();
         // with smallrye-conc-cdi on CP, the CDI thread context provider gets
         // discovered
         weld = new Weld();
         weld.addBeanClasses(MyReqScopedBean.class);
+    }
+
+    @AfterClass
+    public static void stop() {
+        JTAUtils.stop();
     }
 
     @Test


### PR DESCRIPTION
This caches the transaction manager, to avoid CDI bean lookup each time. An application scoped manager bean is introduced to handle CDI shutdown. This is mostly relevant to the test suite rather than the real world, as application servers/frameworks will generally discard a class loader after CDI is shutdown.

Also include a commit that was required to get the tests to pass on my machine.