### PR TITLE
Fix a TCK regression

### DIFF
--- a/core/src/main/java/io/smallrye/context/CompletionStageWrapper.java
+++ b/core/src/main/java/io/smallrye/context/CompletionStageWrapper.java
@@ -28,7 +28,7 @@ public class CompletionStageWrapper<T> implements CompletionStage<T>, Contextual
 
     @Override
     public CompletableFuture<T> toCompletableFuture() {
-        return context.withContextCapture(f.toCompletableFuture(), executor);
+        return context.withContextCapture(f.toCompletableFuture(), executor, CompletableFutureWrapper.FLAG_DEPENDENT);
     }
 
     @Override

--- a/core/src/main/java/io/smallrye/context/JdkSpecific.java
+++ b/core/src/main/java/io/smallrye/context/JdkSpecific.java
@@ -15,7 +15,7 @@ public class JdkSpecific {
                 CompletionStage<T> future, Executor executor);
 
         public <T> CompletableFuture<T> newCompletableFutureWrapper(SmallRyeThreadContext threadContext,
-                CompletableFuture<T> future, Executor executor, boolean minimal);
+                CompletableFuture<T> future, Executor executor, int flags);
     }
 
     public static <T> CompletionStage<T> newCompletionStageWrapper(SmallRyeThreadContext threadContext,
@@ -24,7 +24,7 @@ public class JdkSpecific {
     }
 
     public static <T> CompletableFuture<T> newCompletableFutureWrapper(SmallRyeThreadContext threadContext,
-            CompletableFuture<T> future, Executor executor, boolean minimal) {
-        return impl.newCompletableFutureWrapper(threadContext, future, executor, minimal);
+            CompletableFuture<T> future, Executor executor, int flags) {
+        return impl.newCompletableFutureWrapper(threadContext, future, executor, flags);
     }
 }

--- a/core/src/main/java/io/smallrye/context/SmallRyeManagedExecutor.java
+++ b/core/src/main/java/io/smallrye/context/SmallRyeManagedExecutor.java
@@ -336,7 +336,11 @@ public class SmallRyeManagedExecutor implements ManagedExecutor {
         public SmallRyeManagedExecutor build() {
             ExecutorService executor;
             if (executorService != null)
-                executor = ViewExecutor.builder(executorService).setMaxSize(maxAsync).setQueueLimit(maxQueued).build();
+                executor = ViewExecutor.builder(executorService)
+                        // this is the current max in the implementation (uses short instead of int)
+                        .setMaxSize(maxAsync == -1 ? Short.MAX_VALUE : maxAsync)
+                        .setQueueLimit(maxQueued == -1 ? Integer.MAX_VALUE : maxQueued)
+                        .build();
             else
                 executor = SmallRyeManagedExecutor.newThreadPoolExecutor(maxAsync, maxQueued);
             return new SmallRyeManagedExecutor(maxAsync, maxQueued,

--- a/core/src/main/java/io/smallrye/context/SmallRyeManagedExecutor.java
+++ b/core/src/main/java/io/smallrye/context/SmallRyeManagedExecutor.java
@@ -148,7 +148,7 @@ public class SmallRyeManagedExecutor implements ManagedExecutor {
 
     @Override
     public <U> CompletableFuture<U> completedFuture(U value) {
-        return threadContext.withContextCapture(CompletableFuture.completedFuture(value), this);
+        return threadContext.withContextCapture(CompletableFuture.completedFuture(value), this, 0);
     }
 
     @Override
@@ -160,7 +160,7 @@ public class SmallRyeManagedExecutor implements ManagedExecutor {
     public <U> CompletableFuture<U> failedFuture(Throwable ex) {
         CompletableFuture<U> ret = new CompletableFuture<>();
         ret.completeExceptionally(ex);
-        return threadContext.withContextCapture(ret, this);
+        return threadContext.withContextCapture(ret, this, 0);
     }
 
     @Override
@@ -175,7 +175,7 @@ public class SmallRyeManagedExecutor implements ManagedExecutor {
         // if we contextualise the function it passes to execute(), then our begin/endContext calls will run outside
         // of any thread synchronisation such as join() and it would be all sorts of wrong
         return threadContext.withContextCapture(CompletableFuture
-                .runAsync(threadContext.contextualRunnableUnlessContextualized(runnable), noPropagationExecutor), this);
+                .runAsync(threadContext.contextualRunnableUnlessContextualized(runnable), noPropagationExecutor), this, 0);
     }
 
     @Override
@@ -185,13 +185,13 @@ public class SmallRyeManagedExecutor implements ManagedExecutor {
         // if we contextualise the function it passes to execute(), then our begin/endContext calls will run outside
         // of any thread synchronisation such as join() and it would be all sorts of wrong
         return threadContext.withContextCapture(CompletableFuture
-                .supplyAsync(threadContext.contextualSupplierUnlessContextualized(supplier), noPropagationExecutor), this);
+                .supplyAsync(threadContext.contextualSupplierUnlessContextualized(supplier), noPropagationExecutor), this, 0);
     }
 
     @Override
     public <U> CompletableFuture<U> newIncompleteFuture() {
         CompletableFuture<U> ret = new CompletableFuture<>();
-        return threadContext.withContextCapture(ret, this);
+        return threadContext.withContextCapture(ret, this, 0);
     }
 
     @Override
@@ -264,7 +264,7 @@ public class SmallRyeManagedExecutor implements ManagedExecutor {
      * @return the new completable future.
      */
     public <T> CompletableFuture<T> copy(CompletableFuture<T> stage) {
-        return threadContext.withContextCapture(stage, this);
+        return threadContext.withContextCapture(stage, this, 0);
     }
 
     /**

--- a/core/src/main/java/io/smallrye/context/SmallRyeManagedExecutor.java
+++ b/core/src/main/java/io/smallrye/context/SmallRyeManagedExecutor.java
@@ -329,6 +329,7 @@ public class SmallRyeManagedExecutor implements ManagedExecutor {
             this.cleared = defaultValues.getExecutorCleared();
             this.maxAsync = defaultValues.getExecutorAsync();
             this.maxQueued = defaultValues.getExecutorQueue();
+            this.executorService = manager.getDefaultExecutorService();
         }
 
         @Override

--- a/core/src/main/java/io/smallrye/context/SmallRyeThreadContext.java
+++ b/core/src/main/java/io/smallrye/context/SmallRyeThreadContext.java
@@ -239,11 +239,11 @@ public class SmallRyeThreadContext implements ThreadContext {
      */
     @Override
     public <T> CompletableFuture<T> withContextCapture(CompletableFuture<T> future) {
-        return withContextCapture(future, defaultExecutor);
+        return withContextCapture(future, defaultExecutor, CompletableFutureWrapper.FLAG_DEPENDENT);
     }
 
-    public <T> CompletableFuture<T> withContextCapture(CompletableFuture<T> future, Executor executor) {
-        return JdkSpecific.newCompletableFutureWrapper(this, future, executor, false);
+    public <T> CompletableFuture<T> withContextCapture(CompletableFuture<T> future, Executor executor, int flags) {
+        return JdkSpecific.newCompletableFutureWrapper(this, future, executor, flags);
     }
 
     /**
@@ -286,7 +286,8 @@ public class SmallRyeThreadContext implements ThreadContext {
     public <T> CompletionStage<T> withContextCapture(CompletionStage<T> stage, Executor executor) {
         if (stage instanceof CompletableFuture)
             // the MP-CP TCK insists we cannot complete instances returned by this API
-            return JdkSpecific.newCompletableFutureWrapper(this, (CompletableFuture<T>) stage, executor, true);
+            return JdkSpecific.newCompletableFutureWrapper(this, (CompletableFuture<T>) stage, executor,
+                    CompletableFutureWrapper.FLAG_MINIMAL | CompletableFutureWrapper.FLAG_DEPENDENT);
         return JdkSpecific.newCompletionStageWrapper(this, stage, executor);
     }
 

--- a/core/src/main/java/io/smallrye/context/impl/JdkSpecificImpl.java
+++ b/core/src/main/java/io/smallrye/context/impl/JdkSpecificImpl.java
@@ -19,7 +19,7 @@ public class JdkSpecificImpl implements JdkSpecific.Contract {
 
     @Override
     public <T> CompletableFuture<T> newCompletableFutureWrapper(SmallRyeThreadContext threadContext,
-            CompletableFuture<T> future, Executor executor, boolean minimal) {
-        return new CompletableFutureWrapper<>(threadContext, future, executor, minimal);
+            CompletableFuture<T> future, Executor executor, int flags) {
+        return new CompletableFutureWrapper<>(threadContext, future, executor, flags);
     }
 }

--- a/core/src/main/java9/io/smallrye/context/Jdk9CompletableFutureWrapper.java
+++ b/core/src/main/java9/io/smallrye/context/Jdk9CompletableFutureWrapper.java
@@ -9,14 +9,14 @@ import java.util.function.Supplier;
 public class Jdk9CompletableFutureWrapper<T> extends CompletableFutureWrapper<T> {
 
     public Jdk9CompletableFutureWrapper(SmallRyeThreadContext context, CompletableFuture<T> f, Executor executor,
-            boolean minimal) {
-        super(context, f, executor, minimal);
+            int flags) {
+        super(context, f, executor, flags);
     }
 
     @Override
     public <U> CompletableFuture<U> newIncompleteFuture() {
         CompletableFuture<U> ret = new CompletableFuture<>();
-        return context.withContextCapture(ret, executor);
+        return context.withContextCapture(ret, executor, flags);
     }
 
     @Override
@@ -26,7 +26,7 @@ public class Jdk9CompletableFutureWrapper<T> extends CompletableFutureWrapper<T>
 
     @Override
     public CompletableFuture<T> copy() {
-        return context.withContextCapture(f.copy(), executor);
+        return context.withContextCapture(f.copy(), executor, flags);
     }
 
     @Override
@@ -39,25 +39,25 @@ public class Jdk9CompletableFutureWrapper<T> extends CompletableFutureWrapper<T>
     public CompletableFuture<T> completeAsync(Supplier<? extends T> supplier) {
         // just forward 
         return context.withContextCapture(f.completeAsync(context.contextualSupplierUnlessContextualized(supplier), executor),
-                executor);
+                executor, flags);
     }
 
     @Override
     public CompletableFuture<T> completeAsync(Supplier<? extends T> supplier, Executor executor) {
         // just forward 
         return context.withContextCapture(f.completeAsync(context.contextualSupplierUnlessContextualized(supplier), executor),
-                this.executor);
+                this.executor, flags);
     }
 
     @Override
     public CompletableFuture<T> orTimeout(long timeout, TimeUnit unit) {
         // just forward 
-        return context.withContextCapture(f.orTimeout(timeout, unit), executor);
+        return context.withContextCapture(f.orTimeout(timeout, unit), executor, flags);
     }
 
     @Override
     public CompletableFuture<T> completeOnTimeout(T value, long timeout, TimeUnit unit) {
         // just forward 
-        return context.withContextCapture(f.completeOnTimeout(value, timeout, unit), executor);
+        return context.withContextCapture(f.completeOnTimeout(value, timeout, unit), executor, flags);
     }
 }

--- a/core/src/main/java9/io/smallrye/context/impl/JdkSpecificImpl.java
+++ b/core/src/main/java9/io/smallrye/context/impl/JdkSpecificImpl.java
@@ -19,8 +19,8 @@ public class JdkSpecificImpl implements JdkSpecific.Contract {
 
     @Override
     public <T> CompletableFuture<T> newCompletableFutureWrapper(SmallRyeThreadContext threadContext,
-            CompletableFuture<T> future, Executor executor, boolean minimal) {
-        return new Jdk9CompletableFutureWrapper<>(threadContext, future, executor, minimal);
+            CompletableFuture<T> future, Executor executor, int flags) {
+        return new Jdk9CompletableFutureWrapper<>(threadContext, future, executor, flags);
     }
 
 }

--- a/tests/src/test/java/io/smallrye/context/test/MiscTest.java
+++ b/tests/src/test/java/io/smallrye/context/test/MiscTest.java
@@ -2,12 +2,18 @@ package io.smallrye.context.test;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import org.eclipse.microprofile.context.ThreadContext;
 import org.eclipse.microprofile.context.spi.ContextManager;
 import org.eclipse.microprofile.context.spi.ContextManagerProvider;
 import org.junit.Assert;
 import org.junit.Test;
+
+import io.smallrye.context.SmallRyeContextManager;
+import io.smallrye.context.SmallRyeContextManagerProvider;
 
 public class MiscTest {
 
@@ -20,4 +26,53 @@ public class MiscTest {
         CompletionStage<String> wrapped = threadContext.withContextCapture(cs);
         Assert.assertTrue(wrapped instanceof CompletableFuture);
     }
+
+    /**
+     * Verify that dependent stages created via withContextCapture can be completed independently
+     * of the original stage.
+     * 
+     * Modified from the spec to specify a default executor, which appears to make it fail.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     */
+    @Test
+    public void withContextCaptureDependentStageForcedCompletion() throws ExecutionException, InterruptedException {
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        SmallRyeContextManager contextManager = SmallRyeContextManagerProvider.instance().getContextManagerBuilder()
+                .withDefaultExecutorService(executorService).build();
+        ThreadContext contextPropagator = contextManager.newThreadContextBuilder()
+                .propagated()
+                .unchanged()
+                .cleared(ThreadContext.ALL_REMAINING)
+                .build();
+
+        CompletableFuture<String> stage1 = new CompletableFuture<String>();
+        CompletableFuture<String> stage2 = contextPropagator.withContextCapture(stage1);
+
+        Assert.assertTrue(
+                "It should be possible to complete a CompletableFuture created via withContextCapture without completing the original stage.",
+                stage2.complete("stage_2_done"));
+
+        Assert.assertFalse(
+                "Completion of the dependent stage must not imply completion of the original stage.",
+                stage1.isDone());
+
+        Assert.assertTrue(
+                "It should be possible to complete the original stage with a different result after dependent stage was forcibly completed.",
+                stage1.complete("stage_1_done"));
+
+        Assert.assertEquals(
+                "Completion stage result does not match the result with which it was forcibly completed.",
+                "stage_1_done",
+                stage1.get());
+
+        Assert.assertEquals(
+                "Completion stage result does not match the result with which it was forcibly completed.",
+                "stage_2_done",
+                stage2.get());
+
+        executorService.shutdown();
+    }
+
 }


### PR DESCRIPTION
That only happens on Quarkus because the current TCK doesn't test with an executor service, and Quarkus has one. On Quarkus we'll still have two tests failing until MP-CP releases the new TCK.

Now I've tested with the updated TCK at https://github.com/eclipse/microprofile-context-propagation/pull/197 and we pass.

Also fixed a few bugs spotted while writing the new TCK bits.