### PR TITLE
Contextual thread context

### DIFF
--- a/api/src/main/java/io/smallrye/context/api/CurrentThreadContext.java
+++ b/api/src/main/java/io/smallrye/context/api/CurrentThreadContext.java
@@ -43,6 +43,7 @@ public @interface CurrentThreadContext {
     /**
      * Defines that the current thread context should be removed. This is mutually exclusive
      * with the other settings.
+     * @return a boolean indicating if the current thread context should be removed. Defaults to false.
      */
     @Nonbinding
     public boolean remove() default false;

--- a/api/src/main/java/io/smallrye/context/api/CurrentThreadContext.java
+++ b/api/src/main/java/io/smallrye/context/api/CurrentThreadContext.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2018,2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.context.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.enterprise.util.AnnotationLiteral;
+import javax.enterprise.util.Nonbinding;
+import javax.interceptor.InterceptorBinding;
+
+import org.eclipse.microprofile.context.ThreadContext;
+
+/**
+ * <p>
+ * Declares that a method should be called with its current {@link ThreadContext} set to one created
+ * with the specified settings.
+ * </p>
+ */
+@InterceptorBinding
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.TYPE })
+public @interface CurrentThreadContext {
+
+    /**
+     * Defines that the current thread context should be removed. This is mutually exclusive
+     * with the other settings.
+     */
+    @Nonbinding
+    public boolean remove() default false;
+
+    /**
+     * <p>
+     * Defines the set of thread context types to clear from the thread
+     * where the action or task executes. The previous context is resumed
+     * on the thread after the action or task ends.
+     * </p>
+     *
+     * <p>
+     * By default, no context is cleared/suspended from execution thread.
+     * </p>
+     *
+     * <p>
+     * {@link ThreadContext#ALL_REMAINING} is automatically appended to the
+     * set of cleared context if neither the {@link #propagated} set nor the
+     * {@link #unchanged} set include {@link ThreadContext#ALL_REMAINING}.
+     * </p>
+     *
+     * <p>
+     * Constants for specifying some of the core context types are provided
+     * on {@link ThreadContext}. Other thread context types must be defined
+     * by the specification that defines the context type or by a related
+     * MicroProfile specification.
+     * </p>
+     *
+     * <p>
+     * A <code>ThreadContext</code> must fail to inject, raising
+     * {@link javax.enterprise.inject.spi.DefinitionException DefinitionException}
+     * on application startup,
+     * if a context type specified within this set is unavailable
+     * or if the {@link #propagated} and/or {@link #unchanged} set
+     * includes one or more of the same types as this set.
+     * </p>
+     *
+     * @return an array of strings of thread context types to clear.
+     */
+    @Nonbinding
+    String[] cleared() default {};
+
+    /**
+     * <p>
+     * Defines the set of thread context types to capture from the thread
+     * that contextualizes an action or task. This context is later
+     * re-established on the thread(s) where the action or task executes.
+     * </p>
+     *
+     * <p>
+     * The default set of propagated thread context types is
+     * {@link ThreadContext#ALL_REMAINING}, which includes all available
+     * thread context types that support capture and propagation to other
+     * threads, except for those that are explicitly {@code cleared}.
+     * </p>
+     *
+     * <p>
+     * Constants for specifying some of the core context types are provided
+     * on {@link ThreadContext}. Other thread context types must be defined
+     * by the specification that defines the context type or by a related
+     * MicroProfile specification.
+     * </p>
+     *
+     * <p>
+     * Thread context types which are not otherwise included in this set or
+     * in the {@link #unchanged} set are cleared from the thread of execution
+     * for the duration of the action or task.
+     * </p>
+     *
+     * <p>
+     * A <code>ThreadContext</code> must fail to inject, raising
+     * {@link javax.enterprise.inject.spi.DefinitionException DefinitionException}
+     * on application startup,
+     * if a context type specified within this set is unavailable
+     * or if the {@link #cleared} and/or {@link #unchanged} set
+     * includes one or more of the same types as this set.
+     * </p>
+     *
+     * @return an array of strings of thread context types to propagate.
+     */
+    @Nonbinding
+    String[] propagated() default { ThreadContext.ALL_REMAINING };
+
+    /**
+     * <p>
+     * Defines a set of thread context types that are essentially ignored,
+     * in that they are neither captured nor are they propagated or cleared
+     * from thread(s) that execute the action or task.
+     * </p>
+     *
+     * <p>
+     * Constants for specifying some of the core context types are provided
+     * on {@link ThreadContext}. Other thread context types must be defined
+     * by the specification that defines the context type or by a related
+     * MicroProfile specification.
+     *
+     * <p>
+     * The configuration <code>unchanged</code> context is provided for
+     * advanced patterns where it is desirable to leave certain context types
+     * on the executing thread.
+     * </p>
+     *
+     * <p>
+     * For example, to run as the current application, but under the
+     * transaction of the thread where the task executes:
+     * </p>
+     * 
+     * <pre>
+     * <code> {@literal @}WithThreadContext(unchanged = ThreadContext.TRANSACTION,
+     *                              propagated = ThreadContext.APPLICATION,
+     *                              cleared = ThreadContext.ALL_REMAINING)
+     * public void method() {
+     *   ...
+     *   task = SmallRyeThreadContext.getCurrentThreadContext().contextualRunnable(new MyTransactionalTask());
+     *   ...
+     *   // on another thread,
+     *   tx.begin();
+     *   ...
+     *   task.run(); // runs under the transaction due to 'unchanged'
+     *   tx.commit();
+     * }
+     * </code>
+     * </pre>
+     *
+     * <p>
+     * A <code>ThreadContext</code> must fail to inject, raising
+     * {@link javax.enterprise.inject.spi.DefinitionException DefinitionException}
+     * on application startup,
+     * if a context type specified within this set is unavailable
+     * or if the {@link #cleared} and/or {@link #propagated} set
+     * includes one or more of the same types as this set.
+     * </p>
+     *
+     * @return an array of strings of thread context types to be ignored.
+     */
+    @Nonbinding
+    String[] unchanged() default {};
+
+    /**
+     * Util class used for inline creation of {@link CurrentThreadContext} annotation instances.
+     */
+    final class Literal extends AnnotationLiteral<CurrentThreadContext> implements CurrentThreadContext {
+
+        public static final Literal DEFAULT_INSTANCE = of(false, new String[] {}, new String[] {},
+                new String[] { ThreadContext.ALL_REMAINING });
+
+        private static final long serialVersionUID = 1L;
+
+        private final boolean remove;
+        private final String[] cleared;
+        private final String[] unchanged;
+        private final String[] propagated;
+
+        private Literal(boolean remove, String[] cleared, String[] unchanged, String[] propagated) {
+            this.remove = remove;
+            this.cleared = cleared;
+            this.unchanged = unchanged;
+            this.propagated = propagated;
+        }
+
+        public static Literal of(boolean remove, String[] cleared, String[] unchanged, String[] propagated) {
+            return new Literal(remove, cleared, unchanged, propagated);
+        }
+
+        @Override
+        public boolean remove() {
+            return remove;
+        }
+
+        @Override
+        public String[] cleared() {
+            return cleared;
+        }
+
+        @Override
+        public String[] unchanged() {
+            return unchanged;
+        }
+
+        @Override
+        public String[] propagated() {
+            return propagated;
+        }
+    }
+}

--- a/api/src/main/java/io/smallrye/context/api/CurrentThreadContext.java
+++ b/api/src/main/java/io/smallrye/context/api/CurrentThreadContext.java
@@ -74,7 +74,7 @@ public @interface CurrentThreadContext {
      * </p>
      *
      * <p>
-     * A <code>ThreadContext</code> must fail to inject, raising
+     * A <code>CurrentThreadContext</code> must fail to initialise, raising
      * {@link javax.enterprise.inject.spi.DefinitionException DefinitionException}
      * on application startup,
      * if a context type specified within this set is unavailable
@@ -115,7 +115,7 @@ public @interface CurrentThreadContext {
      * </p>
      *
      * <p>
-     * A <code>ThreadContext</code> must fail to inject, raising
+     * A <code>CurrentThreadContext</code> must fail to initialise, raising
      * {@link javax.enterprise.inject.spi.DefinitionException DefinitionException}
      * on application startup,
      * if a context type specified within this set is unavailable
@@ -170,7 +170,7 @@ public @interface CurrentThreadContext {
      * </pre>
      *
      * <p>
-     * A <code>ThreadContext</code> must fail to inject, raising
+     * A <code>CurrentThreadContext</code> must fail to initialise, raising
      * {@link javax.enterprise.inject.spi.DefinitionException DefinitionException}
      * on application startup,
      * if a context type specified within this set is unavailable

--- a/api/src/main/java/io/smallrye/context/api/CurrentThreadContext.java
+++ b/api/src/main/java/io/smallrye/context/api/CurrentThreadContext.java
@@ -43,6 +43,7 @@ public @interface CurrentThreadContext {
     /**
      * Defines that the current thread context should be removed. This is mutually exclusive
      * with the other settings.
+     * 
      * @return a boolean indicating if the current thread context should be removed. Defaults to false.
      */
     @Nonbinding

--- a/cdi/src/main/java/io/smallrye/context/inject/SmallRyeCurrentThreadContextInterceptor.java
+++ b/cdi/src/main/java/io/smallrye/context/inject/SmallRyeCurrentThreadContextInterceptor.java
@@ -1,5 +1,7 @@
 package io.smallrye.context.inject;
 
+import java.util.Collection;
+
 import javax.annotation.Priority;
 import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
@@ -16,15 +18,33 @@ public class SmallRyeCurrentThreadContextInterceptor {
 
     @AroundInvoke
     public Object manageCurrentContext(InvocationContext ctx) throws Exception {
-        CurrentThreadContext config = ctx.getMethod().getAnnotation(CurrentThreadContext.class);
-        SmallRyeThreadContext newTC = config.remove()
-                ? null
-                : SmallRyeThreadContext.builder()
-                        .cleared(config.cleared())
-                        .propagated(config.propagated())
-                        .unchanged(config.unchanged())
-                        .build();
-        try (CleanAutoCloseable ac = SmallRyeThreadContext.withThreadContext(newTC)) {
+        CurrentThreadContext config = null;
+        Object binding = ctx.getContextData().get("io.quarkus.arc.interceptorBindings");
+        if (binding == null)
+            binding = ctx.getContextData().get("org.jboss.weld.interceptor.bindings");
+        if (binding instanceof Collection) {
+            for (Object b : (Collection<?>) binding) {
+                if (b instanceof CurrentThreadContext) {
+                    config = (CurrentThreadContext) b;
+                    break;
+                }
+            }
+        }
+        if (config == null && ctx.getMethod() != null)
+            config = ctx.getMethod().getAnnotation(CurrentThreadContext.class);
+        if (config != null) {
+            SmallRyeThreadContext newTC = config.remove()
+                    ? null
+                    : SmallRyeThreadContext.builder()
+                            .cleared(config.cleared())
+                            .propagated(config.propagated())
+                            .unchanged(config.unchanged())
+                            .build();
+            try (CleanAutoCloseable ac = SmallRyeThreadContext.withThreadContext(newTC)) {
+                return ctx.proceed();
+            }
+        } else {
+            // could not find any config, that's an error, but we can continue
             return ctx.proceed();
         }
     }

--- a/cdi/src/main/java/io/smallrye/context/inject/SmallRyeCurrentThreadContextInterceptor.java
+++ b/cdi/src/main/java/io/smallrye/context/inject/SmallRyeCurrentThreadContextInterceptor.java
@@ -1,0 +1,31 @@
+package io.smallrye.context.inject;
+
+import javax.annotation.Priority;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+
+import io.smallrye.context.CleanAutoCloseable;
+import io.smallrye.context.SmallRyeThreadContext;
+import io.smallrye.context.api.CurrentThreadContext;
+
+@CurrentThreadContext
+@Interceptor
+@Priority(0)
+public class SmallRyeCurrentThreadContextInterceptor {
+
+    @AroundInvoke
+    public Object manageCurrentContext(InvocationContext ctx) throws Exception {
+        CurrentThreadContext config = ctx.getMethod().getAnnotation(CurrentThreadContext.class);
+        SmallRyeThreadContext newTC = config.remove()
+                ? null
+                : SmallRyeThreadContext.builder()
+                        .cleared(config.cleared())
+                        .propagated(config.propagated())
+                        .unchanged(config.unchanged())
+                        .build();
+        try (CleanAutoCloseable ac = SmallRyeThreadContext.withThreadContext(newTC)) {
+            return ctx.proceed();
+        }
+    }
+}

--- a/cdi/src/main/java/io/smallrye/context/inject/SmallRyeCurrentThreadContextInterceptor.java
+++ b/cdi/src/main/java/io/smallrye/context/inject/SmallRyeCurrentThreadContextInterceptor.java
@@ -13,7 +13,7 @@ import io.smallrye.context.api.CurrentThreadContext;
 
 @CurrentThreadContext
 @Interceptor
-@Priority(0)
+@Priority(Interceptor.Priority.PLATFORM_BEFORE)
 public class SmallRyeCurrentThreadContextInterceptor {
 
     @AroundInvoke

--- a/core/src/main/java/io/smallrye/context/CleanAutoCloseable.java
+++ b/core/src/main/java/io/smallrye/context/CleanAutoCloseable.java
@@ -1,0 +1,12 @@
+package io.smallrye.context;
+
+/**
+ * AutoCloseable interface which doesn't throw.
+ */
+@FunctionalInterface
+public interface CleanAutoCloseable extends AutoCloseable {
+    /**
+     * Close this resource, no exception thrown.
+     */
+    void close();
+}

--- a/core/src/main/java/io/smallrye/context/SmallRyeContextManager.java
+++ b/core/src/main/java/io/smallrye/context/SmallRyeContextManager.java
@@ -1,6 +1,7 @@
 package io.smallrye.context;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -86,7 +87,8 @@ public class SmallRyeContextManager implements ContextManager {
                 || clearedSet.removeAll(propagatedSet) || clearedSet.removeAll(unchangedSet)
                 || unchangedSet.removeAll(propagatedSet) || unchangedSet.removeAll(clearedSet)) {
             throw new IllegalStateException(
-                    "Cannot use ALL_REMAINING in more than one of propagated, cleared, unchanged");
+                    "Cannot use the same context in more than one of propagated (" + Arrays.toString(propagated)
+                            + "), cleared (" + Arrays.toString(cleared) + "), unchanged (" + Arrays.toString(unchanged) + ")");
         }
 
         // expand ALL_REMAINING

--- a/core/src/main/java/io/smallrye/context/SmallRyeThreadContext.java
+++ b/core/src/main/java/io/smallrye/context/SmallRyeThreadContext.java
@@ -22,6 +22,80 @@ import io.smallrye.context.impl.ThreadContextProviderPlan;
 
 public class SmallRyeThreadContext implements ThreadContext {
 
+    private final static ThreadLocal<SmallRyeThreadContext> currentThreadContext = new ThreadLocal<>();
+
+    /**
+     * Updates the current @{link SmallRyeThreadContext} in use by the current thread, and returns an
+     * object suitable for use in try-with-resource to restore the previous value.
+     * 
+     * @param threadContext the @{link SmallRyeThreadContext} to use
+     * @return an object suitable for use in try-with-resource to restore the previous value.
+     */
+    public static CleanAutoCloseable withThreadContext(SmallRyeThreadContext threadContext) {
+        SmallRyeThreadContext oldValue = currentThreadContext.get();
+        currentThreadContext.set(threadContext);
+        return () -> {
+            currentThreadContext.set(oldValue);
+        };
+    }
+
+    /**
+     * Invokes the given @{link Runnable} with the current @{link SmallRyeThreadContext} updated to the given value
+     * for the current thread.
+     * 
+     * @param threadContext the @{link SmallRyeThreadContext} to use
+     * @param f the @{link Runnable} to invoke
+     */
+    public static void withThreadContext(SmallRyeThreadContext threadContext, Runnable f) {
+        try (CleanAutoCloseable foo = withThreadContext(threadContext)) {
+            f.run();
+        }
+    }
+
+    /**
+     * Returns the current thread's @{link SmallRyeThreadContext} if set, or a @{link SmallRyeThreadContext}
+     * which propagates all contexts.
+     * 
+     * @return the current thread's @{link SmallRyeThreadContext} if set, or a @{link SmallRyeThreadContext}
+     *         which propagates all contexts.
+     */
+    public static SmallRyeThreadContext getCurrentThreadContextOrPropagatedContexts() {
+        return getCurrentThreadContext(SmallRyeContextManagerProvider.getManager().allPropagatedThreadContext());
+    }
+
+    /**
+     * Returns the current thread's @{link SmallRyeThreadContext} if set, or a @{link SmallRyeThreadContext}
+     * which clears all contexts.
+     * 
+     * @return the current thread's @{link SmallRyeThreadContext} if set, or a @{link SmallRyeThreadContext}
+     *         which clears all contexts.
+     */
+    public static SmallRyeThreadContext getCurrentThreadContextOrClearedContexts() {
+        return getCurrentThreadContext(SmallRyeContextManagerProvider.getManager().allClearedThreadContext());
+    }
+
+    /**
+     * Returns the current thread's @{link SmallRyeThreadContext} if set, or the given @{link SmallRyeThreadContext}
+     * default value.
+     * 
+     * @param defaultValue the default value to use
+     * @return the current thread's @{link SmallRyeThreadContext} if set, or the given @{link SmallRyeThreadContext}
+     *         default value.
+     */
+    public static SmallRyeThreadContext getCurrentThreadContext(SmallRyeThreadContext defaultValue) {
+        SmallRyeThreadContext threadContext = currentThreadContext.get();
+        return threadContext != null ? threadContext : defaultValue;
+    }
+
+    /**
+     * Returns the current thread's @{link SmallRyeThreadContext} if set, or null.
+     * 
+     * @return the current thread's @{link SmallRyeThreadContext} if set, or null.
+     */
+    public static SmallRyeThreadContext getCurrentThreadContext() {
+        return getCurrentThreadContext(null);
+    }
+
     private final class ContextualSupplier<R> implements Supplier<R>, Contextualized {
         private final CapturedContextState state;
         private final Supplier<R> supplier;
@@ -272,7 +346,7 @@ public class SmallRyeThreadContext implements ThreadContext {
 
     @Override
     public Executor currentContextExecutor() {
-        return withContext(manager.captureContext(plan));
+        return withContext(manager.captureContext(this));
     }
 
     Executor withContext(CapturedContextState state) {
@@ -285,7 +359,7 @@ public class SmallRyeThreadContext implements ThreadContext {
 
     @Override
     public <T, U> BiConsumer<T, U> contextualConsumer(BiConsumer<T, U> consumer) {
-        return contextualConsumer(manager.captureContext(plan), consumer);
+        return contextualConsumer(manager.captureContext(this), consumer);
     }
 
     <T, U> BiConsumer<T, U> contextualConsumerUnlessContextualized(BiConsumer<T, U> consumer) {
@@ -301,7 +375,7 @@ public class SmallRyeThreadContext implements ThreadContext {
 
     @Override
     public <T, U, R> BiFunction<T, U, R> contextualFunction(BiFunction<T, U, R> function) {
-        return contextualFunction(manager.captureContext(plan), function);
+        return contextualFunction(manager.captureContext(this), function);
     }
 
     <T, U, R> BiFunction<T, U, R> contextualFunctionUnlessContextualized(BiFunction<T, U, R> function) {
@@ -317,7 +391,7 @@ public class SmallRyeThreadContext implements ThreadContext {
 
     @Override
     public <R> Callable<R> contextualCallable(Callable<R> callable) {
-        return contextualCallable(manager.captureContext(plan), callable);
+        return contextualCallable(manager.captureContext(this), callable);
     }
 
     <R> Callable<R> contextualCallableUnlessContextualized(Callable<R> callable) {
@@ -333,7 +407,7 @@ public class SmallRyeThreadContext implements ThreadContext {
 
     @Override
     public <T> Consumer<T> contextualConsumer(Consumer<T> consumer) {
-        return contextualConsumer(manager.captureContext(plan), consumer);
+        return contextualConsumer(manager.captureContext(this), consumer);
     }
 
     <T> Consumer<T> contextualConsumerUnlessContextualized(Consumer<T> consumer) {
@@ -349,7 +423,7 @@ public class SmallRyeThreadContext implements ThreadContext {
 
     @Override
     public <T, R> Function<T, R> contextualFunction(Function<T, R> function) {
-        return contextualFunction(manager.captureContext(plan), function);
+        return contextualFunction(manager.captureContext(this), function);
     }
 
     <T, R> Function<T, R> contextualFunctionUnlessContextualized(Function<T, R> function) {
@@ -365,7 +439,7 @@ public class SmallRyeThreadContext implements ThreadContext {
 
     @Override
     public Runnable contextualRunnable(Runnable runnable) {
-        return contextualRunnable(manager.captureContext(plan), runnable);
+        return contextualRunnable(manager.captureContext(this), runnable);
     }
 
     Runnable contextualRunnableUnlessContextualized(Runnable runnable) {
@@ -381,7 +455,7 @@ public class SmallRyeThreadContext implements ThreadContext {
 
     @Override
     public <R> Supplier<R> contextualSupplier(Supplier<R> supplier) {
-        return contextualSupplier(manager.captureContext(plan), supplier);
+        return contextualSupplier(manager.captureContext(this), supplier);
     }
 
     <R> Supplier<R> contextualSupplierUnlessContextualized(Supplier<R> supplier) {

--- a/core/src/main/java/io/smallrye/context/SmallRyeThreadContext.java
+++ b/core/src/main/java/io/smallrye/context/SmallRyeThreadContext.java
@@ -33,11 +33,8 @@ public class SmallRyeThreadContext implements ThreadContext {
 
         @Override
         public R get() {
-            ActiveContextState activeState = state.begin();
-            try {
+            try (ActiveContextState activeState = state.begin()) {
                 return supplier.get();
-            } finally {
-                activeState.endContext();
             }
         }
     }
@@ -53,11 +50,8 @@ public class SmallRyeThreadContext implements ThreadContext {
 
         @Override
         public void run() {
-            ActiveContextState activeState = state.begin();
-            try {
+            try (ActiveContextState activeState = state.begin()) {
                 runnable.run();
-            } finally {
-                activeState.endContext();
             }
         }
     }
@@ -73,11 +67,8 @@ public class SmallRyeThreadContext implements ThreadContext {
 
         @Override
         public R apply(T t) {
-            ActiveContextState activeState = state.begin();
-            try {
+            try (ActiveContextState activeState = state.begin()) {
                 return function.apply(t);
-            } finally {
-                activeState.endContext();
             }
         }
     }
@@ -93,11 +84,8 @@ public class SmallRyeThreadContext implements ThreadContext {
 
         @Override
         public void accept(T t) {
-            ActiveContextState activeState = state.begin();
-            try {
+            try (ActiveContextState activeState = state.begin()) {
                 consumer.accept(t);
-            } finally {
-                activeState.endContext();
             }
         }
     }
@@ -113,11 +101,8 @@ public class SmallRyeThreadContext implements ThreadContext {
 
         @Override
         public R call() throws Exception {
-            ActiveContextState activeState = state.begin();
-            try {
+            try (ActiveContextState activeState = state.begin()) {
                 return callable.call();
-            } finally {
-                activeState.endContext();
             }
         }
     }
@@ -133,11 +118,8 @@ public class SmallRyeThreadContext implements ThreadContext {
 
         @Override
         public R apply(T t, U u) {
-            ActiveContextState activeState = state.begin();
-            try {
+            try (ActiveContextState activeState = state.begin()) {
                 return function.apply(t, u);
-            } finally {
-                activeState.endContext();
             }
         }
     }
@@ -153,11 +135,8 @@ public class SmallRyeThreadContext implements ThreadContext {
 
         @Override
         public void accept(T t, U u) {
-            ActiveContextState activeState = state.begin();
-            try {
+            try (ActiveContextState activeState = state.begin()) {
                 consumer.accept(t, u);
-            } finally {
-                activeState.endContext();
             }
         }
     }
@@ -298,11 +277,8 @@ public class SmallRyeThreadContext implements ThreadContext {
 
     Executor withContext(CapturedContextState state) {
         return (runnable) -> {
-            ActiveContextState activeState = state.begin();
-            try {
+            try (ActiveContextState activeState = state.begin()) {
                 runnable.run();
-            } finally {
-                activeState.endContext();
             }
         };
     }

--- a/core/src/main/java/io/smallrye/context/impl/ActiveContextState.java
+++ b/core/src/main/java/io/smallrye/context/impl/ActiveContextState.java
@@ -6,17 +6,20 @@ import java.util.List;
 import org.eclipse.microprofile.context.spi.ThreadContextController;
 import org.eclipse.microprofile.context.spi.ThreadContextSnapshot;
 
-import io.smallrye.context.SmallRyeContextManager;
+import io.smallrye.context.CleanAutoCloseable;
+import io.smallrye.context.SmallRyeThreadContext;
 
 public class ActiveContextState implements AutoCloseable {
 
     private List<ThreadContextController> activeContext;
+    private CleanAutoCloseable activeThreadContext;
 
-    public ActiveContextState(SmallRyeContextManager context, List<ThreadContextSnapshot> threadContext) {
-        activeContext = new ArrayList<>(threadContext.size());
-        for (ThreadContextSnapshot threadContextSnapshot : threadContext) {
+    public ActiveContextState(SmallRyeThreadContext threadContext, List<ThreadContextSnapshot> threadContextSnapshots) {
+        activeContext = new ArrayList<>(threadContextSnapshots.size());
+        for (ThreadContextSnapshot threadContextSnapshot : threadContextSnapshots) {
             activeContext.add(threadContextSnapshot.begin());
         }
+        activeThreadContext = SmallRyeThreadContext.withThreadContext(threadContext);
     }
 
     public void close() {
@@ -24,5 +27,6 @@ public class ActiveContextState implements AutoCloseable {
         for (int i = activeContext.size() - 1; i >= 0; i--) {
             activeContext.get(i).endContext();
         }
+        activeThreadContext.close();
     }
 }

--- a/core/src/main/java/io/smallrye/context/impl/ActiveContextState.java
+++ b/core/src/main/java/io/smallrye/context/impl/ActiveContextState.java
@@ -8,7 +8,7 @@ import org.eclipse.microprofile.context.spi.ThreadContextSnapshot;
 
 import io.smallrye.context.SmallRyeContextManager;
 
-public class ActiveContextState {
+public class ActiveContextState implements AutoCloseable {
 
     private List<ThreadContextController> activeContext;
 
@@ -19,7 +19,7 @@ public class ActiveContextState {
         }
     }
 
-    public void endContext() {
+    public void close() {
         // restore in reverse order
         for (int i = activeContext.size() - 1; i >= 0; i--) {
             activeContext.get(i).endContext();

--- a/core/src/main/java/io/smallrye/context/impl/CapturedContextState.java
+++ b/core/src/main/java/io/smallrye/context/impl/CapturedContextState.java
@@ -7,31 +7,31 @@ import java.util.Map;
 import org.eclipse.microprofile.context.spi.ThreadContextProvider;
 import org.eclipse.microprofile.context.spi.ThreadContextSnapshot;
 
-import io.smallrye.context.SmallRyeContextManager;
+import io.smallrye.context.SmallRyeThreadContext;
 
 public class CapturedContextState {
 
-    private List<ThreadContextSnapshot> threadContext = new LinkedList<>();
-    private SmallRyeContextManager context;
+    private List<ThreadContextSnapshot> threadContextSnapshots = new LinkedList<>();
+    private SmallRyeThreadContext threadContext;
 
-    public CapturedContextState(SmallRyeContextManager context, ThreadContextProviderPlan plan,
+    public CapturedContextState(SmallRyeThreadContext threadContext, ThreadContextProviderPlan plan,
             Map<String, String> props) {
-        this.context = context;
+        this.threadContext = threadContext;
         for (ThreadContextProvider provider : plan.propagatedProviders) {
             ThreadContextSnapshot snapshot = provider.currentContext(props);
             if (snapshot != null) {
-                threadContext.add(snapshot);
+                threadContextSnapshots.add(snapshot);
             }
         }
         for (ThreadContextProvider provider : plan.clearedProviders) {
             ThreadContextSnapshot snapshot = provider.clearedContext(props);
             if (snapshot != null) {
-                threadContext.add(snapshot);
+                threadContextSnapshots.add(snapshot);
             }
         }
     }
 
     public ActiveContextState begin() {
-        return new ActiveContextState(context, threadContext);
+        return new ActiveContextState(threadContext, threadContextSnapshots);
     }
 }

--- a/core/src/main/java/io/smallrye/context/impl/cdi/SmallRyeCurrentThreadContextInterceptor.java
+++ b/core/src/main/java/io/smallrye/context/impl/cdi/SmallRyeCurrentThreadContextInterceptor.java
@@ -1,4 +1,4 @@
-package io.smallrye.context.inject;
+package io.smallrye.context.impl.cdi;
 
 import java.util.Collection;
 

--- a/jta/src/main/java/io/smallrye/context/jta/context/propagation/JtaContextProvider.java
+++ b/jta/src/main/java/io/smallrye/context/jta/context/propagation/JtaContextProvider.java
@@ -32,6 +32,10 @@ public class JtaContextProvider implements ThreadContextProvider {
             return null;
         }
         TransactionManager tm = tm();
+        if (tm == null) {
+            //return null as per docs to state that propagation of this context is not supported
+            return null;
+        }
         Transaction capturedTransaction = currentTransaction(tm);
         return () -> {
             // Thread
@@ -137,6 +141,10 @@ public class JtaContextProvider implements ThreadContextProvider {
         }
 
         TransactionManager tm = tm();
+        if (tm == null) {
+            //return null as per docs to state that propagation of this context is not supported
+            return null;
+        }
         return () -> {
             // remove/restore current transaction
             Transaction currentTransaction = currentTransaction(tm);

--- a/tests/src/test/java/io/smallrye/context/test/CompletableFutureTest.java
+++ b/tests/src/test/java/io/smallrye/context/test/CompletableFutureTest.java
@@ -55,61 +55,65 @@ public class CompletableFutureTest {
         MyContext ctx = new MyContext();
         MyContext.set(ctx);
         Assert.assertEquals(ctx, MyContext.get());
-        // context in the current thread
-        managedExecutor.completedFuture(null)
-                .thenApply(v -> {
-                    Assert.assertEquals(ctx, MyContext.get());
-                    return v;
-                })
-                .get();
-        // context in the executor thread
-        managedExecutor.completedFuture(null)
-                .thenApplyAsync(v -> {
-                    Assert.assertEquals(ctx, MyContext.get());
-                    return v;
-                })
-                .get();
-        // still with context
-        Assert.assertEquals(ctx, MyContext.get());
+        try {
+            // context in the current thread
+            managedExecutor.completedFuture(null)
+                    .thenApply(v -> {
+                        Assert.assertEquals(ctx, MyContext.get());
+                        return v;
+                    })
+                    .get();
+            // context in the executor thread
+            managedExecutor.completedFuture(null)
+                    .thenApplyAsync(v -> {
+                        Assert.assertEquals(ctx, MyContext.get());
+                        return v;
+                    })
+                    .get();
+            // still with context
+            Assert.assertEquals(ctx, MyContext.get());
 
-        // now create a CF while we have a context
-        CompletableFuture<Void> cfCreatedWithContext = managedExecutor.completedFuture(null);
-        // remove the context
-        MyContext.clear();
+            // now create a CF while we have a context
+            CompletableFuture<Void> cfCreatedWithContext = managedExecutor.completedFuture(null);
+            // remove the context
+            MyContext.clear();
 
-        // check that we get no context, since we're capturing at lambda creation time
-        // nothing in the current thread
-        cfCreatedWithContext
-                .thenApply(v -> {
-                    Assert.assertNull(MyContext.get());
-                    return v;
-                })
-                .get();
-        // nothing in the executor thread
-        cfCreatedWithContext
-                .thenApplyAsync(v -> {
-                    Assert.assertNull(MyContext.get());
-                    return v;
-                })
-                .get();
+            // check that we get no context, since we're capturing at lambda creation time
+            // nothing in the current thread
+            cfCreatedWithContext
+                    .thenApply(v -> {
+                        Assert.assertNull(MyContext.get());
+                        return v;
+                    })
+                    .get();
+            // nothing in the executor thread
+            cfCreatedWithContext
+                    .thenApplyAsync(v -> {
+                        Assert.assertNull(MyContext.get());
+                        return v;
+                    })
+                    .get();
 
-        // now set it to another context and check we get the second context
-        MyContext ctx2 = new MyContext();
-        MyContext.set(ctx2);
-        // context in the current thread
-        cfCreatedWithContext
-                .thenApply(v -> {
-                    Assert.assertEquals(ctx2, MyContext.get());
-                    return v;
-                })
-                .get();
-        // context in the executor thread
-        cfCreatedWithContext
-                .thenApplyAsync(v -> {
-                    Assert.assertEquals(ctx2, MyContext.get());
-                    return v;
-                })
-                .get();
+            // now set it to another context and check we get the second context
+            MyContext ctx2 = new MyContext();
+            MyContext.set(ctx2);
+            // context in the current thread
+            cfCreatedWithContext
+                    .thenApply(v -> {
+                        Assert.assertEquals(ctx2, MyContext.get());
+                        return v;
+                    })
+                    .get();
+            // context in the executor thread
+            cfCreatedWithContext
+                    .thenApplyAsync(v -> {
+                        Assert.assertEquals(ctx2, MyContext.get());
+                        return v;
+                    })
+                    .get();
+        } finally {
+            MyContext.clear();
+        }
     }
 
     @Test
@@ -150,34 +154,38 @@ public class CompletableFutureTest {
 
         MyContext ctx = new MyContext();
         MyContext.set(ctx);
-        CompletableFuture<Object> asyncCompleteCF = managedExecutor.newIncompleteFuture().completeAsync(() -> {
-            Assert.assertEquals(ctx, MyContext.get());
-            return null;
-        });
-        Assert.assertTrue(asyncCompleteCF instanceof Contextualized);
-        Assert.assertNull(asyncCompleteCF.get());
-
-        ExecutorService executor = Executors.newSingleThreadExecutor();
-        asyncCompleteCF = managedExecutor.newIncompleteFuture().completeAsync(() -> {
-            Assert.assertEquals(ctx, MyContext.get());
-            return null;
-        }, executor);
-        Assert.assertTrue(asyncCompleteCF instanceof Contextualized);
-        Assert.assertNull(asyncCompleteCF.get());
-        executor.awaitTermination(2, TimeUnit.SECONDS);
-
-        CompletableFuture<Object> timeoutCF = managedExecutor.newIncompleteFuture().orTimeout(100, TimeUnit.MILLISECONDS);
-        Assert.assertTrue(timeoutCF instanceof Contextualized);
         try {
-            timeoutCF.get();
-            Assert.fail();
-        } catch (ExecutionException x) {
-            Assert.assertTrue(x.getCause() instanceof TimeoutException);
-        }
+            CompletableFuture<Object> asyncCompleteCF = managedExecutor.newIncompleteFuture().completeAsync(() -> {
+                Assert.assertEquals(ctx, MyContext.get());
+                return null;
+            });
+            Assert.assertTrue(asyncCompleteCF instanceof Contextualized);
+            Assert.assertNull(asyncCompleteCF.get());
 
-        timeoutCF = managedExecutor.newIncompleteFuture().completeOnTimeout(null, 100, TimeUnit.MILLISECONDS);
-        Assert.assertTrue(timeoutCF instanceof Contextualized);
-        Assert.assertNull(timeoutCF.get());
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            asyncCompleteCF = managedExecutor.newIncompleteFuture().completeAsync(() -> {
+                Assert.assertEquals(ctx, MyContext.get());
+                return null;
+            }, executor);
+            Assert.assertTrue(asyncCompleteCF instanceof Contextualized);
+            Assert.assertNull(asyncCompleteCF.get());
+            executor.awaitTermination(2, TimeUnit.SECONDS);
+
+            CompletableFuture<Object> timeoutCF = managedExecutor.newIncompleteFuture().orTimeout(100, TimeUnit.MILLISECONDS);
+            Assert.assertTrue(timeoutCF instanceof Contextualized);
+            try {
+                timeoutCF.get();
+                Assert.fail();
+            } catch (ExecutionException x) {
+                Assert.assertTrue(x.getCause() instanceof TimeoutException);
+            }
+
+            timeoutCF = managedExecutor.newIncompleteFuture().completeOnTimeout(null, 100, TimeUnit.MILLISECONDS);
+            Assert.assertTrue(timeoutCF instanceof Contextualized);
+            Assert.assertNull(timeoutCF.get());
+        } finally {
+            MyContext.clear();
+        }
     }
 
     @Test
@@ -189,66 +197,70 @@ public class CompletableFutureTest {
 
         MyContext ctx = new MyContext();
         MyContext.set(ctx);
-        CompletableFuture<String> cfNoContext = cf.thenApplyAsync(v -> {
-            // no context prop on new thread
-            Assert.assertNull(MyContext.get());
-            return v;
-        });
-        CompletableFuture<String> copyThisContext = copy.thenApplyAsync(v -> {
-            // context prop
-            Assert.assertEquals(ctx, MyContext.get());
-            return v;
-        });
-        // change the context to verify that we get the old context
-        MyContext ctx2 = new MyContext();
-        MyContext.set(ctx2);
+        try {
+            CompletableFuture<String> cfNoContext = cf.thenApplyAsync(v -> {
+                // no context prop on new thread
+                Assert.assertNull(MyContext.get());
+                return v;
+            });
+            CompletableFuture<String> copyThisContext = copy.thenApplyAsync(v -> {
+                // context prop
+                Assert.assertEquals(ctx, MyContext.get());
+                return v;
+            });
+            // change the context to verify that we get the old context
+            MyContext ctx2 = new MyContext();
+            MyContext.set(ctx2);
 
-        // check that completing cf completes both
-        cf.complete("OK");
-        Assert.assertEquals("OK", cfNoContext.get());
-        Assert.assertEquals("OK", copyThisContext.get());
+            // check that completing cf completes both
+            cf.complete("OK");
+            Assert.assertEquals("OK", cfNoContext.get());
+            Assert.assertEquals("OK", copyThisContext.get());
 
-        // make sure it has the same contexts
-        SmallRyeThreadContext threadContext = managedExecutor.getThreadContext();
-        Assert.assertNotNull(threadContext);
-        ThreadContextProviderPlan plan = threadContext.getPlan();
-        Assert.assertEquals(4, plan.clearedProviders.size());
-        Assert.assertTrue(plan.unchangedProviders.isEmpty());
-        Assert.assertEquals(1, plan.propagatedProviders.size());
+            // make sure it has the same contexts
+            SmallRyeThreadContext threadContext = managedExecutor.getThreadContext();
+            Assert.assertNotNull(threadContext);
+            ThreadContextProviderPlan plan = threadContext.getPlan();
+            Assert.assertEquals(4, plan.clearedProviders.size());
+            Assert.assertTrue(plan.unchangedProviders.isEmpty());
+            Assert.assertEquals(1, plan.propagatedProviders.size());
 
-        // now make sure ThreadContext can also copy those
-        CompletableFuture<String> cf2 = new CompletableFuture<>();
-        CompletableFuture<String> cf3 = new CompletableFuture<>();
-        CompletableFuture<String> cf2Copy = threadContext.withContextCapture(cf2);
-        // make it pass for a CS
-        CompletionStage<String> cf3Copy = threadContext.withContextCapture((CompletionStage<String>) cf3);
-        Assert.assertFalse(cf2.isDone());
-        Assert.assertFalse(cf2Copy.isDone());
+            // now make sure ThreadContext can also copy those
+            CompletableFuture<String> cf2 = new CompletableFuture<>();
+            CompletableFuture<String> cf3 = new CompletableFuture<>();
+            CompletableFuture<String> cf2Copy = threadContext.withContextCapture(cf2);
+            // make it pass for a CS
+            CompletionStage<String> cf3Copy = threadContext.withContextCapture((CompletionStage<String>) cf3);
+            Assert.assertFalse(cf2.isDone());
+            Assert.assertFalse(cf2Copy.isDone());
 
-        MyContext.set(ctx);
-        CompletableFuture<String> cf2NoContext = cf2.thenApplyAsync(v -> {
-            // no context prop on new thread
-            Assert.assertNull(MyContext.get());
-            return v;
-        });
-        CompletableFuture<String> cf2CopyThisContext = cf2Copy.thenApplyAsync(v -> {
-            // context prop
-            Assert.assertEquals(ctx, MyContext.get());
-            return v;
-        });
-        CompletionStage<String> cf3CopyThisContext = cf3Copy.thenApplyAsync(v -> {
-            // context prop
-            Assert.assertEquals(ctx, MyContext.get());
-            return v;
-        });
-        // change the context to verify that we get the old context
-        MyContext.set(ctx2);
+            MyContext.set(ctx);
+            CompletableFuture<String> cf2NoContext = cf2.thenApplyAsync(v -> {
+                // no context prop on new thread
+                Assert.assertNull(MyContext.get());
+                return v;
+            });
+            CompletableFuture<String> cf2CopyThisContext = cf2Copy.thenApplyAsync(v -> {
+                // context prop
+                Assert.assertEquals(ctx, MyContext.get());
+                return v;
+            });
+            CompletionStage<String> cf3CopyThisContext = cf3Copy.thenApplyAsync(v -> {
+                // context prop
+                Assert.assertEquals(ctx, MyContext.get());
+                return v;
+            });
+            // change the context to verify that we get the old context
+            MyContext.set(ctx2);
 
-        // check that completing cf completes both
-        cf2.complete("OK");
-        cf3.complete("OK");
-        Assert.assertEquals("OK", cf2NoContext.get());
-        Assert.assertEquals("OK", cf2CopyThisContext.get());
-        Assert.assertEquals("OK", cf3CopyThisContext.toCompletableFuture().get());
+            // check that completing cf completes both
+            cf2.complete("OK");
+            cf3.complete("OK");
+            Assert.assertEquals("OK", cf2NoContext.get());
+            Assert.assertEquals("OK", cf2CopyThisContext.get());
+            Assert.assertEquals("OK", cf3CopyThisContext.toCompletableFuture().get());
+        } finally {
+            MyContext.clear();
+        }
     }
 }

--- a/tests/src/test/java/io/smallrye/context/test/CurrentThreadContextTest.java
+++ b/tests/src/test/java/io/smallrye/context/test/CurrentThreadContextTest.java
@@ -1,0 +1,64 @@
+package io.smallrye.context.test;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import io.smallrye.context.CleanAutoCloseable;
+import io.smallrye.context.SmallRyeContextManagerProvider;
+import io.smallrye.context.SmallRyeThreadContext;
+
+public class CurrentThreadContextTest {
+    @Test
+    public void testCurrentThreadContext() throws InterruptedException, ExecutionException {
+        MyContext ctx = new MyContext();
+        MyContext.set(ctx);
+        Assert.assertEquals(ctx, MyContext.get());
+
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        try {
+            // all propagated contexts
+            SmallRyeThreadContext allTC = SmallRyeContextManagerProvider.getManager().allPropagatedThreadContext();
+            Assert.assertNull(SmallRyeThreadContext.getCurrentThreadContext());
+            Runnable r = allTC.contextualRunnable(() -> {
+                Assert.assertEquals(ctx, MyContext.get());
+                Assert.assertEquals(allTC, SmallRyeThreadContext.getCurrentThreadContext());
+            });
+            executorService.submit(r).get();
+
+            // all cleared contexts
+            SmallRyeThreadContext noTC = SmallRyeContextManagerProvider.getManager().allClearedThreadContext();
+            Assert.assertNull(SmallRyeThreadContext.getCurrentThreadContext());
+            r = noTC.contextualRunnable(() -> {
+                Assert.assertNull(MyContext.get());
+                Assert.assertEquals(noTC, SmallRyeThreadContext.getCurrentThreadContext());
+            });
+            executorService.submit(r).get();
+
+            // start with all, then change to no context
+            r = allTC.contextualRunnable(() -> {
+                // all TC
+                Assert.assertEquals(ctx, MyContext.get());
+                Assert.assertEquals(allTC, SmallRyeThreadContext.getCurrentThreadContext());
+                try (CleanAutoCloseable ac = SmallRyeThreadContext.withThreadContext(noTC)) {
+                    Assert.assertEquals(noTC, SmallRyeThreadContext.getCurrentThreadContext());
+                    // no TC
+                    Runnable r2 = SmallRyeThreadContext.getCurrentThreadContext().contextualRunnable(() -> {
+                        Assert.assertNull(MyContext.get());
+                        Assert.assertEquals(noTC, SmallRyeThreadContext.getCurrentThreadContext());
+                    });
+                    executorService.submit(r2).get();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            executorService.submit(r).get();
+        } finally {
+            executorService.shutdownNow();
+            MyContext.clear();
+        }
+    }
+}

--- a/tests/src/test/java/io/smallrye/context/test/cdi/providedBeans/BeanWithCurrentContextMethods.java
+++ b/tests/src/test/java/io/smallrye/context/test/cdi/providedBeans/BeanWithCurrentContextMethods.java
@@ -1,0 +1,83 @@
+package io.smallrye.context.test.cdi.providedBeans;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.spi.CDI;
+
+import org.junit.Assert;
+
+import io.smallrye.context.CleanAutoCloseable;
+import io.smallrye.context.SmallRyeContextManagerProvider;
+import io.smallrye.context.SmallRyeThreadContext;
+import io.smallrye.context.api.CurrentThreadContext;
+import io.smallrye.context.test.MyContext;
+
+@ApplicationScoped
+public class BeanWithCurrentContextMethods {
+
+    @CurrentThreadContext
+    public void assertCurrentContext() throws InterruptedException, ExecutionException {
+        // default is to propagate everything
+        SmallRyeThreadContext allTC = SmallRyeThreadContext.getCurrentThreadContext();
+        Assert.assertNotNull(allTC);
+        MyContext ctx = new MyContext();
+        MyContext.set(ctx);
+        Assert.assertEquals(ctx, MyContext.get());
+
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        try {
+            // all propagated contexts
+            Runnable r = allTC.contextualRunnable(() -> {
+                Assert.assertEquals(ctx, MyContext.get());
+                Assert.assertEquals(allTC, SmallRyeThreadContext.getCurrentThreadContext());
+            });
+            executorService.submit(r).get();
+        } finally {
+            MyContext.clear();
+        }
+    }
+
+    @CurrentThreadContext(propagated = {})
+    public void assertCurrentContextAllCleared() throws InterruptedException, ExecutionException {
+        // default is to propagate nothing
+        SmallRyeThreadContext noTC = SmallRyeThreadContext.getCurrentThreadContext();
+        Assert.assertNotNull(noTC);
+        MyContext ctx = new MyContext();
+        MyContext.set(ctx);
+        Assert.assertEquals(ctx, MyContext.get());
+
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        try {
+            // no propagated contexts
+            Runnable r = noTC.contextualRunnable(() -> {
+                Assert.assertNull(MyContext.get());
+                Assert.assertEquals(noTC, SmallRyeThreadContext.getCurrentThreadContext());
+            });
+            executorService.submit(r).get();
+        } finally {
+            MyContext.clear();
+        }
+    }
+
+    @CurrentThreadContext(remove = true)
+    public void assertCurrentContextRemoved() throws InterruptedException, ExecutionException {
+        // no current context
+        Assert.assertNull(SmallRyeThreadContext.getCurrentThreadContext());
+    }
+
+    public void assertNoCurrentContext() throws InterruptedException, ExecutionException {
+        // no current context
+        Assert.assertNull(SmallRyeThreadContext.getCurrentThreadContext());
+
+        SmallRyeThreadContext clearedTC = SmallRyeContextManagerProvider.getManager().allClearedThreadContext();
+        // make sure we can also remove it via the interceptor
+        try (CleanAutoCloseable ac = SmallRyeThreadContext.withThreadContext(clearedTC)) {
+            Assert.assertEquals(clearedTC, SmallRyeThreadContext.getCurrentThreadContext());
+            // this.calls are not intercepted in Weld 
+            CDI.current().select(BeanWithCurrentContextMethods.class).get().assertCurrentContextRemoved();
+        }
+    }
+}

--- a/tests/src/test/java/io/smallrye/context/test/cdi/providedBeans/CurrentThreadContextInterceptorTest.java
+++ b/tests/src/test/java/io/smallrye/context/test/cdi/providedBeans/CurrentThreadContextInterceptorTest.java
@@ -1,0 +1,42 @@
+package io.smallrye.context.test.cdi.providedBeans;
+
+import java.util.concurrent.ExecutionException;
+
+import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.environment.se.WeldContainer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.smallrye.context.test.JTAUtils;
+
+/**
+ * Tests usage of {@link io.smallrye.context.api.WithCurrentContext}
+ * on methods
+ */
+public class CurrentThreadContextInterceptorTest {
+
+    @Before
+    public void before() {
+        // This is required because even if the JTA ThreadContextProvider can figure out that JTA is not available,
+        // CDI will try to contact JTA via JNDI for its TransactionContext scope, which will break when propagating
+        // the CDI context
+        JTAUtils.startJTATM();
+    }
+
+    @After
+    public void after() {
+        JTAUtils.stop();
+    }
+
+    @Test
+    public void testInterceptor() throws InterruptedException, ExecutionException {
+        try (WeldContainer container = new Weld().addBeanClass(BeanWithCurrentContextMethods.class).initialize()) {
+            BeanWithCurrentContextMethods bean = container.select(BeanWithCurrentContextMethods.class).get();
+            bean.assertCurrentContext();
+            bean.assertCurrentContextAllCleared();
+            bean.assertNoCurrentContext();
+        }
+    }
+
+}


### PR DESCRIPTION
This is for #198 

@cescoffier could you check that it would solve the issue of being able to override propagation settings with Mutiny?

The idea is that the Mutiny/CP integration would start using `SmallRyeThreadContext.getCurrentThreadContextOrPropagatedContexts()` as the source of the `ThreadContext` used for propagation, which would allow users to override settings by scoping stuff like this:

```java
@GET
public Uni<String> foo(){
  Uni<String> allContexts = Uni.createFrom().item("yes").map(v -> v + " with contexts");
  ThreadContext noTC = SmallRyeContextManagerProvider.getManager().allClearedThreadContext();
  try(CleanAutoCloseable ac = SmallRyeThreadContext.withThreadContext(noTC)){
    Uni<String> noContext = Uni.createFrom().item("no").map(v -> v + " without context");
    return noContext.flatMap(v -> allContexts);
  }
}
```