### PR TITLE
Micro performance improvements

### DIFF
--- a/core/src/main/java/io/smallrye/context/SmallRyeContextManager.java
+++ b/core/src/main/java/io/smallrye/context/SmallRyeContextManager.java
@@ -69,8 +69,7 @@ public class SmallRyeContextManager implements ContextManager {
     }
 
     public CapturedContextState captureContext(SmallRyeThreadContext context) {
-        Map<String, String> props = Collections.emptyMap();
-        return new CapturedContextState(context, context.getPlan(), props);
+        return new CapturedContextState(context, context.getPlan());
     }
 
     // for tests

--- a/core/src/main/java/io/smallrye/context/SmallRyeThreadContext.java
+++ b/core/src/main/java/io/smallrye/context/SmallRyeThreadContext.java
@@ -62,8 +62,16 @@ public class SmallRyeThreadContext implements ThreadContext {
      * @param f the @{link Runnable} to invoke
      */
     public static void withThreadContext(SmallRyeThreadContext threadContext, Runnable f) {
-        try (CleanAutoCloseable foo = withThreadContext(threadContext)) {
+        final SmallRyeThreadContext oldValue = currentThreadContext.get();
+        currentThreadContext.set(threadContext);
+        try {
             f.run();
+        } finally {
+            if (oldValue == null) {
+                currentThreadContext.remove();
+            } else {
+                currentThreadContext.set(oldValue);
+            }
         }
     }
 

--- a/core/src/main/java/io/smallrye/context/SmallRyeThreadContext.java
+++ b/core/src/main/java/io/smallrye/context/SmallRyeThreadContext.java
@@ -23,6 +23,12 @@ import io.smallrye.context.impl.ThreadContextProviderPlan;
 public class SmallRyeThreadContext implements ThreadContext {
 
     private final static ThreadLocal<SmallRyeThreadContext> currentThreadContext = new ThreadLocal<>();
+    private final static CleanAutoCloseable NULL_THREAD_STATE = new CleanAutoCloseable() {
+        @Override
+        public void close() {
+            currentThreadContext.remove();
+        }
+    };
 
     /**
      * Updates the current @{link SmallRyeThreadContext} in use by the current thread, and returns an
@@ -34,9 +40,18 @@ public class SmallRyeThreadContext implements ThreadContext {
     public static CleanAutoCloseable withThreadContext(SmallRyeThreadContext threadContext) {
         SmallRyeThreadContext oldValue = currentThreadContext.get();
         currentThreadContext.set(threadContext);
-        return () -> {
-            currentThreadContext.set(oldValue);
-        };
+        if (oldValue == null) {
+            //For restoring null values we can optimise this a little:
+            return NULL_THREAD_STATE;
+        } else {
+            return new CleanAutoCloseable() {
+                @Override
+                public void close() {
+                    currentThreadContext.set(oldValue);
+                }
+            };
+        }
+
     }
 
     /**

--- a/core/src/main/java/io/smallrye/context/impl/ActiveContextState.java
+++ b/core/src/main/java/io/smallrye/context/impl/ActiveContextState.java
@@ -1,6 +1,5 @@
 package io.smallrye.context.impl;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.microprofile.context.spi.ThreadContextController;
@@ -11,21 +10,22 @@ import io.smallrye.context.SmallRyeThreadContext;
 
 public class ActiveContextState implements AutoCloseable {
 
-    private List<ThreadContextController> activeContext;
+    private ThreadContextController[] activeContext;
     private CleanAutoCloseable activeThreadContext;
 
     public ActiveContextState(SmallRyeThreadContext threadContext, List<ThreadContextSnapshot> threadContextSnapshots) {
-        activeContext = new ArrayList<>(threadContextSnapshots.size());
+        activeContext = new ThreadContextController[threadContextSnapshots.size()];
+        int i = 0;
         for (ThreadContextSnapshot threadContextSnapshot : threadContextSnapshots) {
-            activeContext.add(threadContextSnapshot.begin());
+            activeContext[i++] = threadContextSnapshot.begin();
         }
         activeThreadContext = SmallRyeThreadContext.withThreadContext(threadContext);
     }
 
     public void close() {
         // restore in reverse order
-        for (int i = activeContext.size() - 1; i >= 0; i--) {
-            activeContext.get(i).endContext();
+        for (int i = activeContext.length - 1; i >= 0; i--) {
+            activeContext[i].endContext();
         }
         activeThreadContext.close();
     }

--- a/core/src/main/java/io/smallrye/context/impl/CapturedContextState.java
+++ b/core/src/main/java/io/smallrye/context/impl/CapturedContextState.java
@@ -1,11 +1,7 @@
 package io.smallrye.context.impl;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
-import org.eclipse.microprofile.context.spi.ThreadContextProvider;
 import org.eclipse.microprofile.context.spi.ThreadContextSnapshot;
 
 import io.smallrye.context.SmallRyeThreadContext;
@@ -17,20 +13,7 @@ public class CapturedContextState {
 
     public CapturedContextState(SmallRyeThreadContext threadContext, ThreadContextProviderPlan plan) {
         this.threadContext = threadContext;
-        this.threadContextSnapshots = new ArrayList<>(plan.propagatedProviders.size() + plan.clearedProviders.size());
-        final Map<String, String> props = Collections.emptyMap();
-        for (ThreadContextProvider provider : plan.propagatedProviders) {
-            ThreadContextSnapshot snapshot = provider.currentContext(props);
-            if (snapshot != null) {
-                threadContextSnapshots.add(snapshot);
-            }
-        }
-        for (ThreadContextProvider provider : plan.clearedProviders) {
-            ThreadContextSnapshot snapshot = provider.clearedContext(props);
-            if (snapshot != null) {
-                threadContextSnapshots.add(snapshot);
-            }
-        }
+        this.threadContextSnapshots = plan.takeThreadContextSnapshots();
     }
 
     public ActiveContextState begin() {

--- a/core/src/main/java/io/smallrye/context/impl/CapturedContextState.java
+++ b/core/src/main/java/io/smallrye/context/impl/CapturedContextState.java
@@ -1,6 +1,6 @@
 package io.smallrye.context.impl;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -11,12 +11,13 @@ import io.smallrye.context.SmallRyeThreadContext;
 
 public class CapturedContextState {
 
-    private List<ThreadContextSnapshot> threadContextSnapshots = new LinkedList<>();
+    private List<ThreadContextSnapshot> threadContextSnapshots;
     private SmallRyeThreadContext threadContext;
 
     public CapturedContextState(SmallRyeThreadContext threadContext, ThreadContextProviderPlan plan,
             Map<String, String> props) {
         this.threadContext = threadContext;
+        this.threadContextSnapshots = new ArrayList<>(plan.propagatedProviders.size() + plan.clearedProviders.size());
         for (ThreadContextProvider provider : plan.propagatedProviders) {
             ThreadContextSnapshot snapshot = provider.currentContext(props);
             if (snapshot != null) {

--- a/core/src/main/java/io/smallrye/context/impl/CapturedContextState.java
+++ b/core/src/main/java/io/smallrye/context/impl/CapturedContextState.java
@@ -1,6 +1,7 @@
 package io.smallrye.context.impl;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -14,10 +15,10 @@ public class CapturedContextState {
     private List<ThreadContextSnapshot> threadContextSnapshots;
     private SmallRyeThreadContext threadContext;
 
-    public CapturedContextState(SmallRyeThreadContext threadContext, ThreadContextProviderPlan plan,
-            Map<String, String> props) {
+    public CapturedContextState(SmallRyeThreadContext threadContext, ThreadContextProviderPlan plan) {
         this.threadContext = threadContext;
         this.threadContextSnapshots = new ArrayList<>(plan.propagatedProviders.size() + plan.clearedProviders.size());
+        final Map<String, String> props = Collections.emptyMap();
         for (ThreadContextProvider provider : plan.propagatedProviders) {
             ThreadContextSnapshot snapshot = provider.currentContext(props);
             if (snapshot != null) {

--- a/core/src/main/java/io/smallrye/context/impl/ThreadContextProviderPlan.java
+++ b/core/src/main/java/io/smallrye/context/impl/ThreadContextProviderPlan.java
@@ -1,9 +1,13 @@
 package io.smallrye.context.impl;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.microprofile.context.spi.ThreadContextProvider;
+import org.eclipse.microprofile.context.spi.ThreadContextSnapshot;
 
 public class ThreadContextProviderPlan {
 
@@ -11,10 +15,44 @@ public class ThreadContextProviderPlan {
     public final Set<ThreadContextProvider> unchangedProviders;
     public final Set<ThreadContextProvider> clearedProviders;
 
+    /**
+     * Following 3 fields are meant to optimise method #takeThreadContextSnapshots
+     * which is extremely hot at runtime, at cost of little extra memory for this plan.
+     */
+    private final int snapshotInitialSize;
+    private final ThreadContextProvider[] propagatedProvidersFastIterable;
+    private final ThreadContextProvider[] clearedProvidersFastIterable;
+
     public ThreadContextProviderPlan(Set<ThreadContextProvider> propagatedSet, Set<ThreadContextProvider> unchangedSet,
             Set<ThreadContextProvider> clearedSet) {
         this.propagatedProviders = Collections.unmodifiableSet(propagatedSet);
         this.unchangedProviders = Collections.unmodifiableSet(unchangedSet);
         this.clearedProviders = Collections.unmodifiableSet(clearedSet);
+        this.snapshotInitialSize = propagatedProviders.size() + clearedProviders.size();
+        this.propagatedProvidersFastIterable = propagatedProviders.toArray(new ThreadContextProvider[0]);
+        this.clearedProvidersFastIterable = clearedProviders.toArray(new ThreadContextProvider[0]);
+    }
+
+    /**
+     * This helps to optimise construction of CapturedContextState
+     * without exposing too many implementation details.
+     * Only useful for snapshots with an empty property set.
+     */
+    public List<ThreadContextSnapshot> takeThreadContextSnapshots() {
+        List<ThreadContextSnapshot> threadContextSnapshots = new ArrayList<>(snapshotInitialSize);
+        final Map<String, String> props = Collections.emptyMap();
+        for (ThreadContextProvider provider : propagatedProvidersFastIterable) {
+            ThreadContextSnapshot snapshot = provider.currentContext(props);
+            if (snapshot != null) {
+                threadContextSnapshots.add(snapshot);
+            }
+        }
+        for (ThreadContextProvider provider : clearedProvidersFastIterable) {
+            ThreadContextSnapshot snapshot = provider.clearedContext(props);
+            if (snapshot != null) {
+                threadContextSnapshots.add(snapshot);
+            }
+        }
+        return threadContextSnapshots;
     }
 }

--- a/core/src/main/java/io/smallrye/context/impl/ThreadContextProviderPlan.java
+++ b/core/src/main/java/io/smallrye/context/impl/ThreadContextProviderPlan.java
@@ -37,6 +37,8 @@ public class ThreadContextProviderPlan {
      * This helps to optimise construction of CapturedContextState
      * without exposing too many implementation details.
      * Only useful for snapshots with an empty property set.
+     * 
+     * @return a list of snapshots
      */
     public List<ThreadContextSnapshot> takeThreadContextSnapshots() {
         List<ThreadContextSnapshot> threadContextSnapshots = new ArrayList<>(snapshotInitialSize);

--- a/core/src/main/java/io/smallrye/context/impl/ThreadContextProviderPlan.java
+++ b/core/src/main/java/io/smallrye/context/impl/ThreadContextProviderPlan.java
@@ -1,5 +1,6 @@
 package io.smallrye.context.impl;
 
+import java.util.Collections;
 import java.util.Set;
 
 import org.eclipse.microprofile.context.spi.ThreadContextProvider;
@@ -12,8 +13,8 @@ public class ThreadContextProviderPlan {
 
     public ThreadContextProviderPlan(Set<ThreadContextProvider> propagatedSet, Set<ThreadContextProvider> unchangedSet,
             Set<ThreadContextProvider> clearedSet) {
-        this.propagatedProviders = propagatedSet;
-        this.unchangedProviders = unchangedSet;
-        this.clearedProviders = clearedSet;
+        this.propagatedProviders = Collections.unmodifiableSet(propagatedSet);
+        this.unchangedProviders = Collections.unmodifiableSet(unchangedSet);
+        this.clearedProviders = Collections.unmodifiableSet(clearedSet);
     }
 }


### PR DESCRIPTION

Most of these commits are small refactorings and should be semantically equivalent to the current code, but aim at overall savings in memory allocation rates.

Using Techempower, this PR improves the TLAB allocation rate of the Quarkus benchmark by about ~12% total when using the combination RestEasy Reactive + Hibernate Reactive.

Overall, it's all about avoiding allocations for short lived objects; in particular allocating iterators on the HashSet instances of `ThreadContextProviderPlan` is very hot, and performance results suggest the JIT wasn't able to apply escape analysis optimisations in these cases.

I'm not at all familiar with the codebase: code to be patched has been identified via profiling.