### PR TITLE
Release 1.2.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: SmallRye Context Propagation
 release:
-  current-version: 1.1.0
-  next-version: 1.1.1-SNAPSHOT
+  current-version: 1.2.0
+  next-version: 1.2.1-SNAPSHOT

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 	</scm>
 
 	<properties>
-		<version.microprofile.context-propagation>1.1</version.microprofile.context-propagation>
+		<version.microprofile.context-propagation>1.2</version.microprofile.context-propagation>
 		<version.microprofile.config>1.4</version.microprofile.config>
 		<version.smallrye.config>1.9.2</version.smallrye.config>
         <version.jboss.threads>3.1.1.Final</version.jboss.threads>


### PR DESCRIPTION
This aligns the dependency with MP-CP to 1.2, which is the latest release, even though it has no API changes. Just to avoid users reporting we need to bump to the latest release.