### PR TITLE
Added way to get the default configured ThreadContext for Mutiny

### DIFF
--- a/core/src/main/java/io/smallrye/context/SmallRyeContextManager.java
+++ b/core/src/main/java/io/smallrye/context/SmallRyeContextManager.java
@@ -39,6 +39,7 @@ public class SmallRyeContextManager implements ContextManager {
 
     private SmallRyeThreadContext allPropagatedThreadContext;
     private SmallRyeThreadContext allClearedThreadContext;
+    private SmallRyeThreadContext defaultThreadContext;
 
     private final boolean enableFastThreadContextProviders;
 
@@ -209,6 +210,22 @@ public class SmallRyeContextManager implements ContextManager {
 
     //
     // Extras
+
+    /**
+     * Returns a {@link SmallRyeThreadContext} instance which propagates default contexts, possibly
+     * configured via MP Config.
+     * 
+     * @return a {@link SmallRyeThreadContext} instance which propagates default contexts, possibly
+     *         configured via MP Config
+     */
+    public SmallRyeThreadContext defaultThreadContext() {
+        // double parallel instantiation is not an issue
+        if (defaultThreadContext == null) {
+            defaultThreadContext = newThreadContextBuilder()
+                    .build();
+        }
+        return defaultThreadContext;
+    }
 
     /**
      * Returns a {@link SmallRyeThreadContext} instance which propagates all thread contexts.

--- a/core/src/main/java/io/smallrye/context/SmallRyeThreadContext.java
+++ b/core/src/main/java/io/smallrye/context/SmallRyeThreadContext.java
@@ -127,6 +127,40 @@ public class SmallRyeThreadContext implements ThreadContext {
     }
 
     /**
+     * Invokes the given @{link Supplier} with the current @{link SmallRyeThreadContext} updated to the given value
+     * for the current thread.
+     * 
+     * @param threadContext the @{link SmallRyeThreadContext} to use
+     * @param f the @{link Supplier} to invoke
+     * @param <T> The type of @{link Supplier} to return
+     * @return The value returned by the @{link Supplier}
+     */
+    public static <T> T withThreadContext(SmallRyeThreadContext threadContext, Supplier<T> f) {
+        final SmallRyeThreadContext oldValue = currentThreadContext.get();
+        currentThreadContext.set(threadContext);
+        try {
+            return f.get();
+        } finally {
+            if (oldValue == null) {
+                currentThreadContext.remove();
+            } else {
+                currentThreadContext.set(oldValue);
+            }
+        }
+    }
+
+    /**
+     * Returns the current thread's @{link SmallRyeThreadContext} if set, or a @{link SmallRyeThreadContext}
+     * with default contexts, possibly configured via MP Config.
+     * 
+     * @return the current thread's @{link SmallRyeThreadContext} if set, or a @{link SmallRyeThreadContext}
+     *         with default contexts, possibly configured via MP Config.
+     */
+    public static SmallRyeThreadContext getCurrentThreadContextOrDefaultContexts() {
+        return getCurrentThreadContext(SmallRyeContextManagerProvider.getManager().defaultThreadContext());
+    }
+
+    /**
      * Returns the current thread's @{link SmallRyeThreadContext} if set, or a @{link SmallRyeThreadContext}
      * which propagates all contexts.
      * 

--- a/tests/src/test/java/io/smallrye/context/test/CurrentThreadContextTest.java
+++ b/tests/src/test/java/io/smallrye/context/test/CurrentThreadContextTest.java
@@ -29,6 +29,15 @@ public class CurrentThreadContextTest {
             });
             executorService.submit(r).get();
 
+            // default contexts
+            SmallRyeThreadContext defaultTC = SmallRyeContextManagerProvider.getManager().defaultThreadContext();
+            Assert.assertNull(SmallRyeThreadContext.getCurrentThreadContext());
+            r = defaultTC.contextualRunnable(() -> {
+                Assert.assertEquals(ctx, MyContext.get());
+                Assert.assertEquals(defaultTC, SmallRyeThreadContext.getCurrentThreadContext());
+            });
+            executorService.submit(r).get();
+
             // all cleared contexts
             SmallRyeThreadContext noTC = SmallRyeContextManagerProvider.getManager().allClearedThreadContext();
             Assert.assertNull(SmallRyeThreadContext.getCurrentThreadContext());


### PR DESCRIPTION
This allows it to default to all contexts propagated but also use MP Config to override
Also added a withCurrentThreadContext method with Supplier, which is more useful than Runnable
in retrospect