### PR TITLE
Optimized single class-loader use case and enforce thread-safety map accesses

### DIFF
--- a/core/src/main/java/io/smallrye/context/SmallRyeContextManagerProvider.java
+++ b/core/src/main/java/io/smallrye/context/SmallRyeContextManagerProvider.java
@@ -104,8 +104,8 @@ public class SmallRyeContextManagerProvider implements ContextManagerProvider {
                 } else {
                     // abandon the single ctx manager state
                     // concurrencyLevel = 1 because we don't care much about concurrent writes/remove, but just gets
-                    final ConcurrentMap<ClassLoader, SmallRyeContextManager> contextManagersForClassLoader =
-                            new ConcurrentHashMap<>(2, 0.75f, 1);
+                    final ConcurrentMap<ClassLoader, SmallRyeContextManager> contextManagersForClassLoader = new ConcurrentHashMap<>(
+                            2, 0.75f, 1);
                     contextManagersForClassLoader.putAll(singleContextManager);
                     contextManagersForClassLoader.put(classLoader, (SmallRyeContextManager) manager);
                     this.contextManagersForClassLoader = contextManagersForClassLoader;


### PR DESCRIPTION
This PR has been opened to discuss:
1. slowness of map's get due to native (and wasteful) native hashcode (see https://github.com/smallrye/smallrye-context-propagation/pull/399#issuecomment-1364758555)
2. how frequent is the single class loader use case? 
3. why we have unsynchronized access to `HashMap::get`? although no ConcurrentModificationException is throw is not supposed to behave correctly if resizing (due to `put`/`remove`) and racing `get`s

The first issue has been addressed by using singleton/empty specialized states, handling the single class loader use case, while the last is now enforced through `synchronized` blocks while accessing the `> 1` classloader's ctx manager `HashMap`.