### PR TITLE
Generalize ThreadLocal to ThreadScope

### DIFF
--- a/application/src/main/java/io/smallrye/context/application/context/propagation/ApplicationContextProvider.java
+++ b/application/src/main/java/io/smallrye/context/application/context/propagation/ApplicationContextProvider.java
@@ -9,11 +9,12 @@ import org.eclipse.microprofile.context.spi.ThreadContextController;
 import org.eclipse.microprofile.context.spi.ThreadContextSnapshot;
 
 import io.smallrye.context.FastThreadContextProvider;
+import io.smallrye.context.storage.spi.ThreadScope;
 
 public class ApplicationContextProvider implements FastThreadContextProvider {
 
     static final ClassLoader SYSTEM_CL;
-    static final ThreadLocal<ClassLoader> PRETEND_TL = new ThreadLocal<ClassLoader>() {
+    static final ThreadScope<ClassLoader> PRETEND_TL = new ThreadScope<>() {
         @Override
         public ClassLoader get() {
             return Thread.currentThread().getContextClassLoader();
@@ -96,7 +97,7 @@ public class ApplicationContextProvider implements FastThreadContextProvider {
     }
 
     @Override
-    public ThreadLocal<?> threadLocal(Map<String, String> props) {
+    public ThreadScope<?> threadScope(Map<String, String> props) {
         return PRETEND_TL;
     }
 

--- a/core/src/main/java/io/smallrye/context/FastStorageThreadContextProvider.java
+++ b/core/src/main/java/io/smallrye/context/FastStorageThreadContextProvider.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import io.smallrye.context.storage.spi.StorageDeclaration;
 import io.smallrye.context.storage.spi.StorageManager;
+import io.smallrye.context.storage.spi.ThreadScope;
 
 /**
  * Special implementation of a {@link FastThreadContextProvider} if your context is using {@link StorageManager} to obtain its
@@ -15,8 +16,8 @@ public interface FastStorageThreadContextProvider<Declaration extends StorageDec
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    public default ThreadLocal<?> threadLocal(Map<String, String> props) {
-        return StorageManager.threadLocal((Class) getStorageDeclaration());
+    default ThreadScope<?> threadScope(Map<String, String> props) {
+        return StorageManager.threadScope((Class) getStorageDeclaration());
     }
 
     /**

--- a/core/src/main/java/io/smallrye/context/FastThreadContextProvider.java
+++ b/core/src/main/java/io/smallrye/context/FastThreadContextProvider.java
@@ -5,6 +5,8 @@ import java.util.Map;
 import org.eclipse.microprofile.context.spi.ThreadContextProvider;
 import org.eclipse.microprofile.context.spi.ThreadContextSnapshot;
 
+import io.smallrye.context.storage.spi.ThreadScope;
+
 /**
  * Subtype of ThreadContextProvider which bypasses all the {@link #currentContext(Map)} and
  * {@link #clearedContext(Map)} and {@link ThreadContextSnapshot} and just works on the
@@ -19,7 +21,7 @@ public interface FastThreadContextProvider extends ThreadContextProvider {
      * @param props properties
      * @return the ThreadLocal to capture/restore
      */
-    ThreadLocal<?> threadLocal(Map<String, String> props);
+    ThreadScope<?> threadScope(Map<String, String> props);
 
     /**
      * The cleared value. Defaults to null. Override this if your cleared value

--- a/core/src/main/java/io/smallrye/context/SmallRyeThreadContext.java
+++ b/core/src/main/java/io/smallrye/context/SmallRyeThreadContext.java
@@ -61,11 +61,12 @@ import io.smallrye.context.impl.wrappers.SlowContextualFunction;
 import io.smallrye.context.impl.wrappers.SlowContextualRunnable;
 import io.smallrye.context.impl.wrappers.SlowContextualSupplier;
 import io.smallrye.context.storage.spi.StorageManager;
+import io.smallrye.context.storage.spi.ThreadScope;
 
 public class SmallRyeThreadContext implements ThreadContext {
 
-    final static ThreadLocal<SmallRyeThreadContext> currentThreadContext = StorageManager
-            .threadLocal(SmallRyeThreadContextStorageDeclaration.class);
+    private final static ThreadScope<SmallRyeThreadContext> currentThreadContext = StorageManager
+            .threadScope(SmallRyeThreadContextStorageDeclaration.class);
 
     private final static CleanAutoCloseable NULL_THREAD_STATE = new CleanAutoCloseable() {
         @Override

--- a/core/src/main/java/io/smallrye/context/impl/ContextHolder.java
+++ b/core/src/main/java/io/smallrye/context/impl/ContextHolder.java
@@ -1,5 +1,7 @@
 package io.smallrye.context.impl;
 
+import io.smallrye.context.storage.spi.ThreadScope;
+
 /**
  * Interface to be implemented by contextual wrappers so the plan can feed them thread locals.
  */
@@ -13,6 +15,6 @@ public interface ContextHolder {
      * @param threadLocal the context provider's threadLocal
      * @param value the current or cleared value of the threadLocal (depending on ThreadContext settings)
      */
-    void captureThreadLocal(int index, ThreadLocal<Object> threadLocal, Object value);
+    void captureThreadScope(int index, ThreadScope<Object> threadLocal, Object value);
 
 }

--- a/core/src/main/java/io/smallrye/context/impl/ThreadContextProviderPlan.java
+++ b/core/src/main/java/io/smallrye/context/impl/ThreadContextProviderPlan.java
@@ -11,6 +11,7 @@ import org.eclipse.microprofile.context.spi.ThreadContextSnapshot;
 
 import io.smallrye.context.FastThreadContextProvider;
 import io.smallrye.context.SmallRyeThreadContext;
+import io.smallrye.context.storage.spi.ThreadScope;
 
 public class ThreadContextProviderPlan {
 
@@ -101,7 +102,7 @@ public class ThreadContextProviderPlan {
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public void takeThreadContextSnapshotsFast(SmallRyeThreadContext threadContext,
-            ThreadLocal<SmallRyeThreadContext> tcTl,
+            ThreadScope<SmallRyeThreadContext> tcTl,
             ContextHolder contextHolder) {
         if (!fast)
             throw new IllegalStateException("This ThreadContext includes non-fast providers: " + this.clearedProviders + " and "
@@ -111,15 +112,15 @@ public class ThreadContextProviderPlan {
         final Map<String, String> props = Collections.emptyMap();
         int i = 0;
         for (ThreadContextProvider provider : propagatedProvidersFastIterable) {
-            ThreadLocal<?> tl = ((FastThreadContextProvider) provider).threadLocal(props);
-            contextHolder.captureThreadLocal(i++, (ThreadLocal<Object>) tl, tl.get());
+            ThreadScope<?> tl = ((FastThreadContextProvider) provider).threadScope(props);
+            contextHolder.captureThreadScope(i++, (ThreadScope<Object>) tl, tl.get());
         }
         for (ThreadContextProvider provider : clearedProvidersFastIterable) {
-            ThreadLocal<?> tl = ((FastThreadContextProvider) provider).threadLocal(props);
-            contextHolder.captureThreadLocal(i++, (ThreadLocal<Object>) tl,
+            ThreadScope<?> tl = ((FastThreadContextProvider) provider).threadScope(props);
+            contextHolder.captureThreadScope(i++, (ThreadScope<Object>) tl,
                     ((FastThreadContextProvider) provider).clearedValue(props));
         }
-        contextHolder.captureThreadLocal(i, (ThreadLocal) tcTl, threadContext);
+        contextHolder.captureThreadScope(i, (ThreadScope) tcTl, threadContext);
     }
 
     /**

--- a/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualBiConsumer1.java
+++ b/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualBiConsumer1.java
@@ -2,8 +2,10 @@ package io.smallrye.context.impl.wrappers;
 
 import java.util.function.BiConsumer;
 
+import io.smallrye.context.storage.spi.ThreadScope;
+
 public class ContextualBiConsumer1<T, U> implements ContextualBiConsumer<T, U> {
-    private ThreadLocal<Object> tl0;
+    private ThreadScope<Object> tl0;
     private Object state0;
 
     private final BiConsumer<T, U> biConsumer;
@@ -24,10 +26,10 @@ public class ContextualBiConsumer1<T, U> implements ContextualBiConsumer<T, U> {
     }
 
     @Override
-    public void captureThreadLocal(int index, ThreadLocal<Object> threadLocal, Object value) {
+    public void captureThreadScope(int index, ThreadScope<Object> ThreadScope, Object value) {
         switch (index) {
             case 0:
-                tl0 = threadLocal;
+                tl0 = ThreadScope;
                 state0 = value;
                 break;
             default:

--- a/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualBiConsumer2.java
+++ b/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualBiConsumer2.java
@@ -2,10 +2,12 @@ package io.smallrye.context.impl.wrappers;
 
 import java.util.function.BiConsumer;
 
+import io.smallrye.context.storage.spi.ThreadScope;
+
 public class ContextualBiConsumer2<T, U> implements ContextualBiConsumer<T, U> {
-    private ThreadLocal<Object> tl0;
+    private ThreadScope<Object> tl0;
     private Object state0;
-    private ThreadLocal<Object> tl1;
+    private ThreadScope<Object> tl1;
     private Object state1;
 
     private final BiConsumer<T, U> biConsumer;
@@ -29,14 +31,14 @@ public class ContextualBiConsumer2<T, U> implements ContextualBiConsumer<T, U> {
     }
 
     @Override
-    public void captureThreadLocal(int index, ThreadLocal<Object> threadLocal, Object value) {
+    public void captureThreadScope(int index, ThreadScope<Object> ThreadScope, Object value) {
         switch (index) {
             case 0:
-                tl0 = threadLocal;
+                tl0 = ThreadScope;
                 state0 = value;
                 break;
             case 1:
-                tl1 = threadLocal;
+                tl1 = ThreadScope;
                 state1 = value;
                 break;
             default:

--- a/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualBiConsumerN.java
+++ b/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualBiConsumerN.java
@@ -2,15 +2,17 @@ package io.smallrye.context.impl.wrappers;
 
 import java.util.function.BiConsumer;
 
+import io.smallrye.context.storage.spi.ThreadScope;
+
 public class ContextualBiConsumerN<T, U> implements ContextualBiConsumer<T, U> {
-    private ThreadLocal<Object>[] tl;
+    private ThreadScope<Object>[] tl;
     private Object[] state;
 
     private final BiConsumer<T, U> biConsumer;
 
     public ContextualBiConsumerN(BiConsumer<T, U> biConsumer, int n) {
         this.biConsumer = biConsumer;
-        this.tl = new ThreadLocal[n];
+        this.tl = new ThreadScope[n];
         this.state = new Object[n];
     }
 
@@ -31,10 +33,10 @@ public class ContextualBiConsumerN<T, U> implements ContextualBiConsumer<T, U> {
     }
 
     @Override
-    public void captureThreadLocal(int index, ThreadLocal<Object> threadLocal, Object value) {
+    public void captureThreadScope(int index, ThreadScope<Object> ThreadScope, Object value) {
         if (index < 0 || index >= state.length)
             throw new IllegalArgumentException("Illegal index " + index);
-        tl[index] = threadLocal;
+        tl[index] = ThreadScope;
         state[index] = value;
     }
 

--- a/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualBiFunction1.java
+++ b/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualBiFunction1.java
@@ -2,8 +2,10 @@ package io.smallrye.context.impl.wrappers;
 
 import java.util.function.BiFunction;
 
+import io.smallrye.context.storage.spi.ThreadScope;
+
 public class ContextualBiFunction1<T, U, R> implements ContextualBiFunction<T, U, R> {
-    private ThreadLocal<Object> tl0;
+    private ThreadScope<Object> tl0;
     private Object state0;
 
     private final BiFunction<T, U, R> biFunction;
@@ -24,10 +26,10 @@ public class ContextualBiFunction1<T, U, R> implements ContextualBiFunction<T, U
     }
 
     @Override
-    public void captureThreadLocal(int index, ThreadLocal<Object> threadLocal, Object value) {
+    public void captureThreadScope(int index, ThreadScope<Object> ThreadScope, Object value) {
         switch (index) {
             case 0:
-                tl0 = threadLocal;
+                tl0 = ThreadScope;
                 state0 = value;
                 break;
             default:

--- a/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualBiFunction2.java
+++ b/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualBiFunction2.java
@@ -2,10 +2,12 @@ package io.smallrye.context.impl.wrappers;
 
 import java.util.function.BiFunction;
 
+import io.smallrye.context.storage.spi.ThreadScope;
+
 public class ContextualBiFunction2<T, U, R> implements ContextualBiFunction<T, U, R> {
-    private ThreadLocal<Object> tl0;
+    private ThreadScope<Object> tl0;
     private Object state0;
-    private ThreadLocal<Object> tl1;
+    private ThreadScope<Object> tl1;
     private Object state1;
 
     private final BiFunction<T, U, R> biFunction;
@@ -29,14 +31,14 @@ public class ContextualBiFunction2<T, U, R> implements ContextualBiFunction<T, U
     }
 
     @Override
-    public void captureThreadLocal(int index, ThreadLocal<Object> threadLocal, Object value) {
+    public void captureThreadScope(int index, ThreadScope<Object> ThreadScope, Object value) {
         switch (index) {
             case 0:
-                tl0 = threadLocal;
+                tl0 = ThreadScope;
                 state0 = value;
                 break;
             case 1:
-                tl1 = threadLocal;
+                tl1 = ThreadScope;
                 state1 = value;
                 break;
             default:

--- a/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualBiFunctionN.java
+++ b/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualBiFunctionN.java
@@ -2,15 +2,17 @@ package io.smallrye.context.impl.wrappers;
 
 import java.util.function.BiFunction;
 
+import io.smallrye.context.storage.spi.ThreadScope;
+
 public class ContextualBiFunctionN<T, U, R> implements ContextualBiFunction<T, U, R> {
-    private ThreadLocal<Object>[] tl;
+    private ThreadScope<Object>[] tl;
     private Object[] state;
 
     private final BiFunction<T, U, R> biFunction;
 
     public ContextualBiFunctionN(BiFunction<T, U, R> biFunction, int n) {
         this.biFunction = biFunction;
-        this.tl = new ThreadLocal[n];
+        this.tl = new ThreadScope[n];
         this.state = new Object[n];
     }
 
@@ -31,10 +33,10 @@ public class ContextualBiFunctionN<T, U, R> implements ContextualBiFunction<T, U
     }
 
     @Override
-    public void captureThreadLocal(int index, ThreadLocal<Object> threadLocal, Object value) {
+    public void captureThreadScope(int index, ThreadScope<Object> ThreadScope, Object value) {
         if (index < 0 || index >= state.length)
             throw new IllegalArgumentException("Illegal index " + index);
-        tl[index] = threadLocal;
+        tl[index] = ThreadScope;
         state[index] = value;
     }
 

--- a/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualCallable1.java
+++ b/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualCallable1.java
@@ -2,8 +2,10 @@ package io.smallrye.context.impl.wrappers;
 
 import java.util.concurrent.Callable;
 
+import io.smallrye.context.storage.spi.ThreadScope;
+
 public class ContextualCallable1<T> implements ContextualCallable<T> {
-    private ThreadLocal<Object> tl0;
+    private ThreadScope<Object> tl0;
     private Object state0;
 
     private final Callable<T> callable;
@@ -24,10 +26,10 @@ public class ContextualCallable1<T> implements ContextualCallable<T> {
     }
 
     @Override
-    public void captureThreadLocal(int index, ThreadLocal<Object> threadLocal, Object value) {
+    public void captureThreadScope(int index, ThreadScope<Object> ThreadScope, Object value) {
         switch (index) {
             case 0:
-                tl0 = threadLocal;
+                tl0 = ThreadScope;
                 state0 = value;
                 break;
             default:

--- a/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualCallable2.java
+++ b/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualCallable2.java
@@ -2,10 +2,12 @@ package io.smallrye.context.impl.wrappers;
 
 import java.util.concurrent.Callable;
 
+import io.smallrye.context.storage.spi.ThreadScope;
+
 public class ContextualCallable2<T> implements ContextualCallable<T> {
-    private ThreadLocal<Object> tl0;
+    private ThreadScope<Object> tl0;
     private Object state0;
-    private ThreadLocal<Object> tl1;
+    private ThreadScope<Object> tl1;
     private Object state1;
 
     private final Callable<T> callable;
@@ -29,14 +31,14 @@ public class ContextualCallable2<T> implements ContextualCallable<T> {
     }
 
     @Override
-    public void captureThreadLocal(int index, ThreadLocal<Object> threadLocal, Object value) {
+    public void captureThreadScope(int index, ThreadScope<Object> ThreadScope, Object value) {
         switch (index) {
             case 0:
-                tl0 = threadLocal;
+                tl0 = ThreadScope;
                 state0 = value;
                 break;
             case 1:
-                tl1 = threadLocal;
+                tl1 = ThreadScope;
                 state1 = value;
                 break;
             default:

--- a/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualCallableN.java
+++ b/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualCallableN.java
@@ -2,15 +2,17 @@ package io.smallrye.context.impl.wrappers;
 
 import java.util.concurrent.Callable;
 
+import io.smallrye.context.storage.spi.ThreadScope;
+
 public class ContextualCallableN<T> implements ContextualCallable<T> {
-    private ThreadLocal<Object>[] tl;
+    private ThreadScope<Object>[] tl;
     private Object[] state;
 
     private final Callable<T> callable;
 
     public ContextualCallableN(Callable<T> callable, int n) {
         this.callable = callable;
-        this.tl = new ThreadLocal[n];
+        this.tl = new ThreadScope[n];
         this.state = new Object[n];
     }
 
@@ -31,10 +33,10 @@ public class ContextualCallableN<T> implements ContextualCallable<T> {
     }
 
     @Override
-    public void captureThreadLocal(int index, ThreadLocal<Object> threadLocal, Object value) {
+    public void captureThreadScope(int index, ThreadScope<Object> ThreadScope, Object value) {
         if (index < 0 || index >= state.length)
             throw new IllegalArgumentException("Illegal index " + index);
-        tl[index] = threadLocal;
+        tl[index] = ThreadScope;
         state[index] = value;
     }
 

--- a/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualConsumer1.java
+++ b/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualConsumer1.java
@@ -2,8 +2,10 @@ package io.smallrye.context.impl.wrappers;
 
 import java.util.function.Consumer;
 
+import io.smallrye.context.storage.spi.ThreadScope;
+
 public class ContextualConsumer1<T> implements ContextualConsumer<T> {
-    private ThreadLocal<Object> tl0;
+    private ThreadScope<Object> tl0;
     private Object state0;
 
     private final Consumer<T> consumer;
@@ -24,10 +26,10 @@ public class ContextualConsumer1<T> implements ContextualConsumer<T> {
     }
 
     @Override
-    public void captureThreadLocal(int index, ThreadLocal<Object> threadLocal, Object value) {
+    public void captureThreadScope(int index, ThreadScope<Object> ThreadScope, Object value) {
         switch (index) {
             case 0:
-                tl0 = threadLocal;
+                tl0 = ThreadScope;
                 state0 = value;
                 break;
             default:

--- a/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualConsumer2.java
+++ b/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualConsumer2.java
@@ -2,10 +2,12 @@ package io.smallrye.context.impl.wrappers;
 
 import java.util.function.Consumer;
 
+import io.smallrye.context.storage.spi.ThreadScope;
+
 public class ContextualConsumer2<T> implements ContextualConsumer<T> {
-    private ThreadLocal<Object> tl0;
+    private ThreadScope<Object> tl0;
     private Object state0;
-    private ThreadLocal<Object> tl1;
+    private ThreadScope<Object> tl1;
     private Object state1;
 
     private final Consumer<T> consumer;
@@ -29,14 +31,14 @@ public class ContextualConsumer2<T> implements ContextualConsumer<T> {
     }
 
     @Override
-    public void captureThreadLocal(int index, ThreadLocal<Object> threadLocal, Object value) {
+    public void captureThreadScope(int index, ThreadScope<Object> ThreadScope, Object value) {
         switch (index) {
             case 0:
-                tl0 = threadLocal;
+                tl0 = ThreadScope;
                 state0 = value;
                 break;
             case 1:
-                tl1 = threadLocal;
+                tl1 = ThreadScope;
                 state1 = value;
                 break;
             default:

--- a/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualConsumerN.java
+++ b/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualConsumerN.java
@@ -2,15 +2,17 @@ package io.smallrye.context.impl.wrappers;
 
 import java.util.function.Consumer;
 
+import io.smallrye.context.storage.spi.ThreadScope;
+
 public class ContextualConsumerN<T> implements ContextualConsumer<T> {
-    private ThreadLocal<Object>[] tl;
+    private ThreadScope<Object>[] tl;
     private Object[] state;
 
     private final Consumer<T> consumer;
 
     public ContextualConsumerN(Consumer<T> consumer, int n) {
         this.consumer = consumer;
-        this.tl = new ThreadLocal[n];
+        this.tl = new ThreadScope[n];
         this.state = new Object[n];
     }
 
@@ -31,10 +33,10 @@ public class ContextualConsumerN<T> implements ContextualConsumer<T> {
     }
 
     @Override
-    public void captureThreadLocal(int index, ThreadLocal<Object> threadLocal, Object value) {
+    public void captureThreadScope(int index, ThreadScope<Object> ThreadScope, Object value) {
         if (index < 0 || index >= state.length)
             throw new IllegalArgumentException("Illegal index " + index);
-        tl[index] = threadLocal;
+        tl[index] = ThreadScope;
         state[index] = value;
     }
 

--- a/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualExecutor1.java
+++ b/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualExecutor1.java
@@ -1,7 +1,9 @@
 package io.smallrye.context.impl.wrappers;
 
+import io.smallrye.context.storage.spi.ThreadScope;
+
 public class ContextualExecutor1 implements ContextualExecutor {
-    private ThreadLocal<Object> tl0;
+    private ThreadScope<Object> tl0;
     private Object state0;
 
     @Override
@@ -16,10 +18,10 @@ public class ContextualExecutor1 implements ContextualExecutor {
     }
 
     @Override
-    public void captureThreadLocal(int index, ThreadLocal<Object> threadLocal, Object value) {
+    public void captureThreadScope(int index, ThreadScope<Object> ThreadScope, Object value) {
         switch (index) {
             case 0:
-                tl0 = threadLocal;
+                tl0 = ThreadScope;
                 state0 = value;
                 break;
             default:

--- a/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualExecutor2.java
+++ b/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualExecutor2.java
@@ -1,9 +1,11 @@
 package io.smallrye.context.impl.wrappers;
 
+import io.smallrye.context.storage.spi.ThreadScope;
+
 public class ContextualExecutor2 implements ContextualExecutor {
-    private ThreadLocal<Object> tl0;
+    private ThreadScope<Object> tl0;
     private Object state0;
-    private ThreadLocal<Object> tl1;
+    private ThreadScope<Object> tl1;
     private Object state1;
 
     @Override
@@ -21,14 +23,14 @@ public class ContextualExecutor2 implements ContextualExecutor {
     }
 
     @Override
-    public void captureThreadLocal(int index, ThreadLocal<Object> threadLocal, Object value) {
+    public void captureThreadScope(int index, ThreadScope<Object> ThreadScope, Object value) {
         switch (index) {
             case 0:
-                tl0 = threadLocal;
+                tl0 = ThreadScope;
                 state0 = value;
                 break;
             case 1:
-                tl1 = threadLocal;
+                tl1 = ThreadScope;
                 state1 = value;
                 break;
             default:

--- a/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualExecutorN.java
+++ b/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualExecutorN.java
@@ -1,11 +1,13 @@
 package io.smallrye.context.impl.wrappers;
 
+import io.smallrye.context.storage.spi.ThreadScope;
+
 public class ContextualExecutorN implements ContextualExecutor {
-    private ThreadLocal<Object>[] tl;
+    private ThreadScope<Object>[] tl;
     private Object[] state;
 
     public ContextualExecutorN(int n) {
-        this.tl = new ThreadLocal[n];
+        this.tl = new ThreadScope[n];
         this.state = new Object[n];
     }
 
@@ -26,10 +28,10 @@ public class ContextualExecutorN implements ContextualExecutor {
     }
 
     @Override
-    public void captureThreadLocal(int index, ThreadLocal<Object> threadLocal, Object value) {
+    public void captureThreadScope(int index, ThreadScope<Object> ThreadScope, Object value) {
         if (index < 0 || index >= state.length)
             throw new IllegalArgumentException("Illegal index " + index);
-        tl[index] = threadLocal;
+        tl[index] = ThreadScope;
         state[index] = value;
     }
 

--- a/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualFunction1.java
+++ b/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualFunction1.java
@@ -2,8 +2,10 @@ package io.smallrye.context.impl.wrappers;
 
 import java.util.function.Function;
 
+import io.smallrye.context.storage.spi.ThreadScope;
+
 public class ContextualFunction1<T, R> implements ContextualFunction<T, R> {
-    private ThreadLocal<Object> tl0;
+    private ThreadScope<Object> tl0;
     private Object state0;
 
     private final Function<T, R> function;
@@ -24,10 +26,10 @@ public class ContextualFunction1<T, R> implements ContextualFunction<T, R> {
     }
 
     @Override
-    public void captureThreadLocal(int index, ThreadLocal<Object> threadLocal, Object value) {
+    public void captureThreadScope(int index, ThreadScope<Object> ThreadScope, Object value) {
         switch (index) {
             case 0:
-                tl0 = threadLocal;
+                tl0 = ThreadScope;
                 state0 = value;
                 break;
             default:

--- a/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualFunction2.java
+++ b/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualFunction2.java
@@ -2,10 +2,12 @@ package io.smallrye.context.impl.wrappers;
 
 import java.util.function.Function;
 
+import io.smallrye.context.storage.spi.ThreadScope;
+
 public class ContextualFunction2<T, R> implements ContextualFunction<T, R> {
-    private ThreadLocal<Object> tl0;
+    private ThreadScope<Object> tl0;
     private Object state0;
-    private ThreadLocal<Object> tl1;
+    private ThreadScope<Object> tl1;
     private Object state1;
 
     private final Function<T, R> function;
@@ -29,14 +31,14 @@ public class ContextualFunction2<T, R> implements ContextualFunction<T, R> {
     }
 
     @Override
-    public void captureThreadLocal(int index, ThreadLocal<Object> threadLocal, Object value) {
+    public void captureThreadScope(int index, ThreadScope<Object> ThreadScope, Object value) {
         switch (index) {
             case 0:
-                tl0 = threadLocal;
+                tl0 = ThreadScope;
                 state0 = value;
                 break;
             case 1:
-                tl1 = threadLocal;
+                tl1 = ThreadScope;
                 state1 = value;
                 break;
             default:

--- a/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualFunctionN.java
+++ b/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualFunctionN.java
@@ -2,15 +2,17 @@ package io.smallrye.context.impl.wrappers;
 
 import java.util.function.Function;
 
+import io.smallrye.context.storage.spi.ThreadScope;
+
 public class ContextualFunctionN<T, R> implements ContextualFunction<T, R> {
-    private ThreadLocal<Object>[] tl;
+    private ThreadScope<Object>[] tl;
     private Object[] state;
 
     private final Function<T, R> function;
 
     public ContextualFunctionN(Function<T, R> function, int n) {
         this.function = function;
-        this.tl = new ThreadLocal[n];
+        this.tl = new ThreadScope[n];
         this.state = new Object[n];
     }
 
@@ -31,10 +33,10 @@ public class ContextualFunctionN<T, R> implements ContextualFunction<T, R> {
     }
 
     @Override
-    public void captureThreadLocal(int index, ThreadLocal<Object> threadLocal, Object value) {
+    public void captureThreadScope(int index, ThreadScope<Object> ThreadScope, Object value) {
         if (index < 0 || index >= state.length)
             throw new IllegalArgumentException("Illegal index " + index);
-        tl[index] = threadLocal;
+        tl[index] = ThreadScope;
         state[index] = value;
     }
 

--- a/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualRunnable1.java
+++ b/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualRunnable1.java
@@ -1,7 +1,9 @@
 package io.smallrye.context.impl.wrappers;
 
+import io.smallrye.context.storage.spi.ThreadScope;
+
 public final class ContextualRunnable1 implements ContextualRunnable {
-    private ThreadLocal<Object> tl0;
+    private ThreadScope<Object> tl0;
     private Object state0;
 
     private final Runnable runnable;
@@ -22,10 +24,10 @@ public final class ContextualRunnable1 implements ContextualRunnable {
     }
 
     @Override
-    public void captureThreadLocal(int index, ThreadLocal<Object> threadLocal, Object value) {
+    public void captureThreadScope(int index, ThreadScope<Object> ThreadScope, Object value) {
         switch (index) {
             case 0:
-                tl0 = threadLocal;
+                tl0 = ThreadScope;
                 state0 = value;
                 break;
             default:

--- a/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualRunnable2.java
+++ b/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualRunnable2.java
@@ -1,9 +1,11 @@
 package io.smallrye.context.impl.wrappers;
 
+import io.smallrye.context.storage.spi.ThreadScope;
+
 public final class ContextualRunnable2 implements ContextualRunnable {
-    private ThreadLocal<Object> tl0;
+    private ThreadScope<Object> tl0;
     private Object state0;
-    private ThreadLocal<Object> tl1;
+    private ThreadScope<Object> tl1;
     private Object state1;
 
     private final Runnable runnable;
@@ -27,14 +29,14 @@ public final class ContextualRunnable2 implements ContextualRunnable {
     }
 
     @Override
-    public void captureThreadLocal(int index, ThreadLocal<Object> threadLocal, Object value) {
+    public void captureThreadScope(int index, ThreadScope<Object> ThreadScope, Object value) {
         switch (index) {
             case 0:
-                tl0 = threadLocal;
+                tl0 = ThreadScope;
                 state0 = value;
                 break;
             case 1:
-                tl1 = threadLocal;
+                tl1 = ThreadScope;
                 state1 = value;
                 break;
             default:

--- a/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualRunnableN.java
+++ b/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualRunnableN.java
@@ -1,14 +1,16 @@
 package io.smallrye.context.impl.wrappers;
 
+import io.smallrye.context.storage.spi.ThreadScope;
+
 public final class ContextualRunnableN implements ContextualRunnable {
-    private ThreadLocal<Object>[] tl;
+    private ThreadScope<Object>[] tl;
     private Object[] state;
 
     private final Runnable runnable;
 
     public ContextualRunnableN(Runnable runnable, int n) {
         this.runnable = runnable;
-        this.tl = new ThreadLocal[n];
+        this.tl = new ThreadScope[n];
         this.state = new Object[n];
     }
 
@@ -29,10 +31,10 @@ public final class ContextualRunnableN implements ContextualRunnable {
     }
 
     @Override
-    public void captureThreadLocal(int index, ThreadLocal<Object> threadLocal, Object value) {
+    public void captureThreadScope(int index, ThreadScope<Object> ThreadScope, Object value) {
         if (index < 0 || index >= state.length)
             throw new IllegalArgumentException("Illegal index " + index);
-        tl[index] = threadLocal;
+        tl[index] = ThreadScope;
         state[index] = value;
     }
 }

--- a/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualSupplier1.java
+++ b/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualSupplier1.java
@@ -2,8 +2,10 @@ package io.smallrye.context.impl.wrappers;
 
 import java.util.function.Supplier;
 
+import io.smallrye.context.storage.spi.ThreadScope;
+
 public final class ContextualSupplier1<R> implements ContextualSupplier<R> {
-    private ThreadLocal<Object> tl0;
+    private ThreadScope<Object> tl0;
     private Object state0;
 
     private final Supplier<R> supplier;
@@ -24,10 +26,10 @@ public final class ContextualSupplier1<R> implements ContextualSupplier<R> {
     }
 
     @Override
-    public void captureThreadLocal(int index, ThreadLocal<Object> threadLocal, Object value) {
+    public void captureThreadScope(int index, ThreadScope<Object> ThreadScope, Object value) {
         switch (index) {
             case 0:
-                tl0 = threadLocal;
+                tl0 = ThreadScope;
                 state0 = value;
                 break;
             default:

--- a/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualSupplier2.java
+++ b/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualSupplier2.java
@@ -31,7 +31,7 @@ public final class ContextualSupplier2<R> implements ContextualSupplier<R> {
     }
 
     @Override
-    public void captureThreadScope(int index, ThreadScope<Object> ThreadScope, Object value) {
+    public void captureThreadScope(int index, ThreadScope<Object> threadScope, Object value) {
         switch (index) {
             case 0:
                 tl0 = ThreadScope;

--- a/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualSupplier2.java
+++ b/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualSupplier2.java
@@ -2,10 +2,12 @@ package io.smallrye.context.impl.wrappers;
 
 import java.util.function.Supplier;
 
+import io.smallrye.context.storage.spi.ThreadScope;
+
 public final class ContextualSupplier2<R> implements ContextualSupplier<R> {
-    private ThreadLocal<Object> tl0;
+    private ThreadScope<Object> tl0;
     private Object state0;
-    private ThreadLocal<Object> tl1;
+    private ThreadScope<Object> tl1;
     private Object state1;
 
     private final Supplier<R> supplier;
@@ -29,14 +31,14 @@ public final class ContextualSupplier2<R> implements ContextualSupplier<R> {
     }
 
     @Override
-    public void captureThreadLocal(int index, ThreadLocal<Object> threadLocal, Object value) {
+    public void captureThreadScope(int index, ThreadScope<Object> ThreadScope, Object value) {
         switch (index) {
             case 0:
-                tl0 = threadLocal;
+                tl0 = ThreadScope;
                 state0 = value;
                 break;
             case 1:
-                tl1 = threadLocal;
+                tl1 = ThreadScope;
                 state1 = value;
                 break;
             default:

--- a/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualSupplierN.java
+++ b/core/src/main/java/io/smallrye/context/impl/wrappers/ContextualSupplierN.java
@@ -2,15 +2,17 @@ package io.smallrye.context.impl.wrappers;
 
 import java.util.function.Supplier;
 
+import io.smallrye.context.storage.spi.ThreadScope;
+
 public final class ContextualSupplierN<R> implements ContextualSupplier<R> {
-    private ThreadLocal<Object>[] tl;
+    private ThreadScope<Object>[] tl;
     private Object[] state;
 
     private final Supplier<R> supplier;
 
     public ContextualSupplierN(Supplier<R> supplier, int n) {
         this.supplier = supplier;
-        this.tl = new ThreadLocal[n];
+        this.tl = new ThreadScope[n];
         this.state = new Object[n];
     }
 
@@ -31,10 +33,10 @@ public final class ContextualSupplierN<R> implements ContextualSupplier<R> {
     }
 
     @Override
-    public void captureThreadLocal(int index, ThreadLocal<Object> threadLocal, Object value) {
+    public void captureThreadScope(int index, ThreadScope<Object> ThreadScope, Object value) {
         if (index < 0 || index >= state.length)
             throw new IllegalArgumentException("Illegal index " + index);
-        tl[index] = threadLocal;
+        tl[index] = ThreadScope;
         state[index] = value;
     }
 }

--- a/storage/src/main/java/io/smallrye/context/storage/impl/DefaultStorageManager.java
+++ b/storage/src/main/java/io/smallrye/context/storage/impl/DefaultStorageManager.java
@@ -5,19 +5,20 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import io.smallrye.context.storage.spi.StorageDeclaration;
 import io.smallrye.context.storage.spi.StorageManager;
+import io.smallrye.context.storage.spi.ThreadScope;
 
 /**
  * Default implementation which allocates new regular ThreadLocal for any storage declaration class.
  */
 public class DefaultStorageManager implements StorageManager {
 
-    private final Map<Class<?>, ThreadLocal<?>> threadLocals = new ConcurrentHashMap<>();
+    private final Map<Class<?>, ThreadScope<?>> threadLocals = new ConcurrentHashMap<>();
 
     /**
      * Returns a regular ThreadLocal specific for the given storage declaration.
      */
     @Override
-    public <T extends StorageDeclaration<X>, X> ThreadLocal<X> getThreadLocal(Class<T> klass) {
-        return (ThreadLocal<X>) threadLocals.computeIfAbsent(klass, v -> new ThreadLocal<>());
+    public <T extends StorageDeclaration<X>, X> ThreadScope<X> getThreadScope(Class<T> klass) {
+        return (ThreadScope<X>) threadLocals.computeIfAbsent(klass, v -> new ThreadLocalScope<>());
     }
 }

--- a/storage/src/main/java/io/smallrye/context/storage/impl/ThreadLocalScope.java
+++ b/storage/src/main/java/io/smallrye/context/storage/impl/ThreadLocalScope.java
@@ -1,0 +1,31 @@
+package io.smallrye.context.storage.impl;
+
+import io.smallrye.context.storage.spi.ThreadScope;
+
+public class ThreadLocalScope<T> implements ThreadScope<T> {
+
+    protected final ThreadLocal<T> threadLocal;
+
+    public ThreadLocalScope() {
+        this(new ThreadLocal<>());
+    }
+
+    public ThreadLocalScope(ThreadLocal<T> threadLocal) {
+        this.threadLocal = threadLocal;
+    }
+
+    @Override
+    public T get() {
+        return threadLocal.get();
+    }
+
+    @Override
+    public void set(T value) {
+        threadLocal.set(value);
+    }
+
+    @Override
+    public void remove() {
+        threadLocal.remove();
+    }
+}

--- a/storage/src/main/java/io/smallrye/context/storage/impl/UnsfafeThreadLocalScope.java
+++ b/storage/src/main/java/io/smallrye/context/storage/impl/UnsfafeThreadLocalScope.java
@@ -1,0 +1,19 @@
+package io.smallrye.context.storage.impl;
+
+public class UnsfafeThreadLocalScope<T> extends ThreadLocalScope<T> {
+
+    public UnsfafeThreadLocalScope() {
+        super(new ThreadLocal<>());
+    }
+
+    public UnsfafeThreadLocalScope(ThreadLocal<T> threadLocal) {
+        super(threadLocal);
+    }
+
+    @Override
+    public void remove() {
+        // Implement a faster remove that however could cause memory leaks in some cases
+        // see https://github.com/spring-cloud/spring-cloud-sleuth/issues/27
+        threadLocal.set(null);
+    }
+}

--- a/storage/src/main/java/io/smallrye/context/storage/impl/UnsfafeThreadLocalScope.java
+++ b/storage/src/main/java/io/smallrye/context/storage/impl/UnsfafeThreadLocalScope.java
@@ -1,6 +1,6 @@
 package io.smallrye.context.storage.impl;
 
-public class UnsfafeThreadLocalScope<T> extends ThreadLocalScope<T> {
+public class UnsafeThreadLocalScope<T> extends ThreadLocalScope<T> {
 
     public UnsfafeThreadLocalScope() {
         super(new ThreadLocal<>());

--- a/storage/src/main/java/io/smallrye/context/storage/spi/StorageManager.java
+++ b/storage/src/main/java/io/smallrye/context/storage/spi/StorageManager.java
@@ -10,7 +10,7 @@ public interface StorageManager {
      *
      * @return the currently registered StorageManager
      */
-    public static StorageManager instance() {
+    static StorageManager instance() {
         return StorageManagerProvider.instance().getStorageManager();
     }
 
@@ -26,7 +26,7 @@ public interface StorageManager {
      * @param <T> The StorageDeclaration type
      * @param <X> The type of data we store in that ThreadLocal
      */
-    public <T extends StorageDeclaration<X>, X> ThreadLocal<X> getThreadLocal(Class<T> storageDeclarationClass);
+    <T extends StorageDeclaration<X>, X> ThreadScope<X> getThreadScope(Class<T> storageDeclarationClass);
 
     /**
      * Obtains a ThreadLocal suitable for the given registered StorageDeclaration. The ThreadLocal
@@ -40,7 +40,7 @@ public interface StorageManager {
      * @param <T> The StorageDeclaration type
      * @param <X> The type of data we store in that ThreadLocal
      */
-    public static <T extends StorageDeclaration<X>, X> ThreadLocal<X> threadLocal(Class<T> storageDeclarationClass) {
-        return instance().getThreadLocal(storageDeclarationClass);
+    static <T extends StorageDeclaration<X>, X> ThreadScope<X> threadScope(Class<T> storageDeclarationClass) {
+        return instance().getThreadScope(storageDeclarationClass);
     }
 }

--- a/storage/src/main/java/io/smallrye/context/storage/spi/StorageManagerProvider.java
+++ b/storage/src/main/java/io/smallrye/context/storage/spi/StorageManagerProvider.java
@@ -12,7 +12,7 @@ import io.smallrye.context.storage.impl.DefaultStorageManagerProvider;
  */
 public interface StorageManagerProvider {
 
-    static AtomicReference<StorageManagerProvider> INSTANCE = new AtomicReference<StorageManagerProvider>();
+    AtomicReference<StorageManagerProvider> INSTANCE = new AtomicReference<StorageManagerProvider>();
 
     /**
      * Returns the currently registered StorageManagerProvider. Will attempt to instantiate one based on
@@ -21,7 +21,7 @@ public interface StorageManagerProvider {
      *
      * @return the currently registered StorageManagerProvider, lazily created.
      */
-    public static StorageManagerProvider instance() {
+    static StorageManagerProvider instance() {
         StorageManagerProvider provider = INSTANCE.get();
         if (provider == null) {
             for (StorageManagerProvider serviceProvider : ServiceLoader.load(StorageManagerProvider.class)) {
@@ -45,7 +45,7 @@ public interface StorageManagerProvider {
      * @return a registration object allowing you to unregister it
      * @throws IllegalStateException when there already is a registered provider
      */
-    public static StorageManagerProviderRegistration register(StorageManagerProvider provider) throws IllegalStateException {
+    static StorageManagerProviderRegistration register(StorageManagerProvider provider) throws IllegalStateException {
         if (INSTANCE.compareAndSet(null, provider)) {
             return new StorageManagerProviderRegistration(provider);
         } else {
@@ -56,7 +56,7 @@ public interface StorageManagerProvider {
     /**
      * @return the current StorageManager, for the current TCCL
      */
-    public default StorageManager getStorageManager() {
+    default StorageManager getStorageManager() {
         ClassLoader loader = System.getSecurityManager() == null
                 ? Thread.currentThread().getContextClassLoader()
                 : AccessController
@@ -70,5 +70,5 @@ public interface StorageManagerProvider {
      * @param classloader the classloader to use for looking up the StorageManager
      * @return the StorageManager registered for the given ClassLoader
      */
-    public StorageManager getStorageManager(ClassLoader classloader);
+    StorageManager getStorageManager(ClassLoader classloader);
 }

--- a/storage/src/main/java/io/smallrye/context/storage/spi/ThreadScope.java
+++ b/storage/src/main/java/io/smallrye/context/storage/spi/ThreadScope.java
@@ -1,0 +1,10 @@
+package io.smallrye.context.storage.spi;
+
+public interface ThreadScope<T> {
+
+    T get();
+
+    void set(T value);
+
+    void remove();
+}

--- a/testsuite/extra/src/main/java/io/smallrye/context/test/MyContext.java
+++ b/testsuite/extra/src/main/java/io/smallrye/context/test/MyContext.java
@@ -2,13 +2,14 @@ package io.smallrye.context.test;
 
 import io.smallrye.context.storage.spi.StorageDeclaration;
 import io.smallrye.context.storage.spi.StorageManager;
+import io.smallrye.context.storage.spi.ThreadScope;
 
 public class MyContext {
 
     static class Declaration implements StorageDeclaration<MyContext> {
     }
 
-    static ThreadLocal<MyContext> context = StorageManager.threadLocal(Declaration.class);
+    static ThreadScope<MyContext> context = StorageManager.threadScope(Declaration.class);
 
     public static void init() {
         context.set(new MyContext());

--- a/testsuite/extra/src/test/java/io/smallrye/context/storage/QuarkusStorageManager.java
+++ b/testsuite/extra/src/test/java/io/smallrye/context/storage/QuarkusStorageManager.java
@@ -1,26 +1,29 @@
 package io.smallrye.context.storage;
 
 import io.smallrye.context.impl.SmallRyeThreadContextStorageDeclaration;
+import io.smallrye.context.storage.impl.ThreadLocalScope;
 import io.smallrye.context.storage.spi.StorageDeclaration;
 import io.smallrye.context.storage.spi.StorageManager;
+import io.smallrye.context.storage.spi.ThreadScope;
 
 /**
  * To be implemented in Quarkus
  */
 class QuarkusStorageManager implements StorageManager {
 
-    private final static ThreadLocal<?> resteasyStorage = new RESTEasy_QuarkusStorage();
-    private final static ThreadLocal<?> threadContextStorage = new SmallRyeThreadContext_QuarkusStorage();
+    private final static ThreadScope<?> resteasyStorage = new ThreadLocalScope<>(new RESTEasy_QuarkusStorage());
+    private final static ThreadScope<?> threadContextStorage = new ThreadLocalScope<>(
+            new SmallRyeThreadContext_QuarkusStorage());
 
     /**
      * This part will be generated depending on the discovered StorageUsers
      */
     @Override
-    public <T extends StorageDeclaration<X>, X> ThreadLocal<X> getThreadLocal(Class<T> klass) {
+    public <T extends StorageDeclaration<X>, X> ThreadScope<X> getThreadScope(Class<T> klass) {
         if (klass == RESTEasyStorageDeclaration.class)
-            return (ThreadLocal<X>) resteasyStorage;
+            return (ThreadScope<X>) resteasyStorage;
         if (klass == SmallRyeThreadContextStorageDeclaration.class)
-            return (ThreadLocal<X>) threadContextStorage;
+            return (ThreadScope<X>) threadContextStorage;
         throw new IllegalArgumentException("Storage user nor registered: " + klass);
     }
 

--- a/testsuite/extra/src/test/java/io/smallrye/context/storage/RESTEasyContext.java
+++ b/testsuite/extra/src/test/java/io/smallrye/context/storage/RESTEasyContext.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 
 import io.smallrye.context.storage.spi.StorageManager;
+import io.smallrye.context.storage.spi.ThreadScope;
 
 /**
  * This is a fake version of ResteasyContext from RESTEasy, where it stores its ThreadLocal Stack of Map contexts.
@@ -13,8 +14,8 @@ import io.smallrye.context.storage.spi.StorageManager;
  */
 class RESTEasyContext {
 
-    static final ThreadLocal<List<Map<Class<?>, Object>>> context = StorageManager
-            .threadLocal(RESTEasyStorageDeclaration.class);
+    static final ThreadScope<List<Map<Class<?>, Object>>> context = StorageManager
+            .threadScope(RESTEasyStorageDeclaration.class);
 
     static <T> T getContext(Class<T> klass) {
         Map<Class<?>, Object> context = getContext();


### PR DESCRIPTION
This pull request is a proposal to solve [this issue](https://github.com/smallrye/smallrye-context-propagation/issues/424) and also a generalization of the `ThreadLocal`s' usage made inside smallrye allowing to plug different implementations including something more virtual threads friendly.

I understand that replacing `ThreadLocal` with the new `ThreadScope` interface that I introduced with this pull request is quite invasive and could have a (relevant?) impact on other projects downstream. Nevertheless I believe that exposing `ThreadLocal` as we did so far is a leaky abstraction obliging us to use a very specific implementation for a quite general purpose.

In essence this solution has a twofold advantage:

1. Exposing only the new `ThreadScope` interface limits the use of a ThreadLocal-like data structure to the only 3 methods that we really need.
2. Even more important its introduction allows to use different and more efficient implementations that we couldn't use otherwise. For instance netty's `FastThreadLocal` which doesn't extend `ThreadLocal` or some other future implementations also playing well with virtual threads.

/cc @FroMage @Sanne @geoand @franz1981