### PR TITLE
Avoid ClassLoader identityHashCode and fix concurrency of ctx manager lookup table

### DIFF
--- a/core/src/main/java/io/smallrye/context/SingleWriterCopyOnWriteArrayIdentityMap.java
+++ b/core/src/main/java/io/smallrye/context/SingleWriterCopyOnWriteArrayIdentityMap.java
@@ -1,0 +1,101 @@
+package io.smallrye.context;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+/**
+ * This lookup map is optimized for the case where there is a single writer and multiple readers.
+ * <p>
+ * This map is not thread-safe for multiple writers and is not optimized for many entries, given
+ * that is backed by an ordered array and uses linear search.
+ */
+final class SingleWriterCopyOnWriteArrayIdentityMap<K, V> {
+
+    private static final AtomicReferenceFieldUpdater<SingleWriterCopyOnWriteArrayIdentityMap, Object[]> ENTRIES_UPDATER = AtomicReferenceFieldUpdater
+            .newUpdater(SingleWriterCopyOnWriteArrayIdentityMap.class, Object[].class, "entries");
+
+    private static final Object[] EMPTY_ARRAY = new Object[0];
+
+    private volatile Object[] entries;
+
+    public SingleWriterCopyOnWriteArrayIdentityMap() {
+        ENTRIES_UPDATER.lazySet(this, EMPTY_ARRAY);
+    }
+
+    public V get(K key) {
+        final Object[] array = this.entries;
+        for (int i = 0; i < array.length; i += 2) {
+            if (array[i] == key) {
+                return (V) array[i + 1];
+            }
+        }
+        return null;
+    }
+
+    public void put(K key, V value) {
+        Object[] oldEntries = entries;
+        // verify if the key already exists in the array
+        // or if the value is the same
+        int keyIndex = -1;
+        for (int i = 0; i < oldEntries.length; i += 2) {
+            if (oldEntries[i] == key) {
+                if (oldEntries[i + 1] == value) {
+                    return;
+                }
+                keyIndex = i;
+                break;
+            }
+        }
+        final Object[] newEntries;
+        if (keyIndex != -1) {
+            // key already exists, but the value is different
+            newEntries = new Object[oldEntries.length];
+            System.arraycopy(oldEntries, 0, newEntries, 0, oldEntries.length);
+            newEntries[keyIndex + 1] = value;
+        } else {
+            // key does not exist, add it
+            newEntries = new Object[oldEntries.length + 2];
+            System.arraycopy(oldEntries, 0, newEntries, 0, oldEntries.length);
+            newEntries[oldEntries.length] = key;
+            newEntries[oldEntries.length + 1] = value;
+        }
+        ENTRIES_UPDATER.lazySet(this, newEntries);
+    }
+
+    public void removeEntriesWithValue(V value) {
+        final Object[] oldEntries = entries;
+        // verify first where the first value is found
+        int firstKeyWithValueMatches = -1;
+        for (int i = 0; i < oldEntries.length; i += 2) {
+            if (oldEntries[i + 1] == value) {
+                firstKeyWithValueMatches = i;
+                break;
+            }
+        }
+        if (firstKeyWithValueMatches == -1) {
+            // value not found
+            return;
+        }
+        // create a new ArrayList of survivors (we're generous with the initial size)
+        Object[] newEntries = new Object[oldEntries.length - 2];
+        // copy the first part of the array till the matching key/value pair
+        if (firstKeyWithValueMatches > 0) {
+            System.arraycopy(oldEntries, 0, newEntries, 0, firstKeyWithValueMatches);
+        }
+        int newIdx = firstKeyWithValueMatches;
+        // filter and add the other key/value pairs, not matching the value
+        for (int i = firstKeyWithValueMatches + 2; i < oldEntries.length; i += 2) {
+            if (oldEntries[i + 1] != value) {
+                newEntries[newIdx] = oldEntries[i];
+                newEntries[newIdx + 1] = oldEntries[i + 1];
+                newIdx += 2;
+            }
+        }
+        // create a new exact array if necessary
+        if (newIdx < newEntries.length) {
+            newEntries = newIdx == 0 ? EMPTY_ARRAY : Arrays.copyOf(newEntries, newIdx);
+        }
+        ENTRIES_UPDATER.lazySet(this, newEntries);
+    }
+
+}

--- a/core/src/main/java/io/smallrye/context/SingleWriterCopyOnWriteArrayIdentityMap.java
+++ b/core/src/main/java/io/smallrye/context/SingleWriterCopyOnWriteArrayIdentityMap.java
@@ -19,6 +19,7 @@ final class SingleWriterCopyOnWriteArrayIdentityMap<K, V> {
     private volatile Object[] entries;
 
     public SingleWriterCopyOnWriteArrayIdentityMap() {
+        // lazySet is enough, as we don't expect multiple writers: it is semantically the same as VarHandle::setRelease
         ENTRIES_UPDATER.lazySet(this, EMPTY_ARRAY);
     }
 


### PR DESCRIPTION
It replaces https://github.com/smallrye/smallrye-context-propagation/pull/399


Quoting the @Sanne comments at https://github.com/smallrye/smallrye-context-propagation/pull/399#issuecomment-1370764330

> we could optimize for very few ? e.g. I believe Quarkus in the most common production configuration has two - seems fit for a linear scan. I don't know about other runtimes using this library but I'd expect them to run also with very few classloaders; e.g. WildFly has many classloaders but I expect only a handful would be visible to this - theory that would need to be verified though.

If this approach is pushing too far the assumption about being **very few** ...
1. I could consider adding  property to let the application decide if uses this one, or the previous implementation (which I need to correctly pack in a separate class)
2. I can make it super dynamic and expose instead, a sensible cutoff value (or none, by deciding ourselves for the users!), which can transform the array map into a proper one (likely need something thread-safe :/)
